### PR TITLE
Typo at line #513

### DIFF
--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -510,7 +510,7 @@ For multidimensional arrays, indexes are tuples of integers:
            [0, 0, 2]])
     >>> a[1, 1]
     1
-    >>> a[2, 1] = 10 # third line, second column
+    >>> a[2, 1] = 0 # third line, second column
     >>> a
     array([[ 0,  0,  0],
            [ 0,  1,  0],


### PR DESCRIPTION
At line #513, Result of "a[2, 1]" should be "0" instead of "10".