### PR TITLE
Correct typo in data types section

### DIFF
--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -350,8 +350,8 @@ There are also other types:
 
     * ``int32``
     * ``int64``
-    * ``unit32``
-    * ``unit64``
+    * ``uint32``
+    * ``uint64``
 
 .. XXX: mention: astype
 


### PR DESCRIPTION
Reference to `unit32` and `unit64` data types corrected to `uint32` and `uint64`.