### PR TITLE
make two failing doctests in mathematical_optimization pass

### DIFF
--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -927,7 +927,7 @@ as box bounds can be rewritten as such via change of variables.
     >>> def f(x):
     ...    return np.sqrt((x[0] - 3)**2 + (x[1] - 2)**2)
     >>> optimize.fmin_l_bfgs_b(f, np.array([0, 0]), approx_grad=1, bounds=((-1.5, 1.5), (-1.5, 1.5)))
-
+    (array([ 1.5,  1.5]), 1.5811388300841898, {'warnflag': 0, 'task': 'CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL', 'grad': array([-0.94868331, -0.31622778]), 'nit': 2, 'funcalls': 12})
 
 
 General constraints

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -886,6 +886,9 @@ While it is possible to construct our optimization problem ourselves,
 scipy provides a helper function for this purpose:
 :func:`scipy.optimize.curve_fit`::
 
+.. Comment to make doctest pass
+    >>> np.random.seed(0)
+
     >>> def f(t, omega, phi):
     ...     return np.cos(omega * t + phi)
     
@@ -893,8 +896,9 @@ scipy provides a helper function for this purpose:
     >>> y = f(x, 1.5, 1) + .1*np.random.normal(size=50)
 
     >>> optimize.curve_fit(f, x, y)
-    (array([ 1.52129341,  0.96084285]), array([[ 0.00032879, -0.00049033],
-           [-0.00049033,  0.00106799]]))
+    (array([ 1.51854577,  0.92665541]), array([[ 0.00037994, -0.00056796],
+           [-0.00056796,  0.00123978]]))
+
 
 .. topic:: **Exercise**
    :class: green


### PR DESCRIPTION
After rerunning the tests, it seems that there are still two problems which this PR attempts to solve.
* In one case a random seed has to be set.
* In another case, it seems that the output of `optimize.fmin_l_bfgs_b` got lost. It is restored with this PR.
