### PR TITLE
Fixes in image_prossessing/index.rst

### DIFF
--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -666,10 +666,10 @@ Use mathematical morphology to clean up the result::
 	>>> tmp = np.logical_not(reconstruct_img)
 	>>> eroded_tmp = ndimage.binary_erosion(tmp)
 	>>> reconstruct_final = np.logical_not(ndimage.binary_propagation(eroded_tmp, mask=tmp))
-	>>> np.abs(mask - close_img).mean()
-	0.014678955078125
-	>>> np.abs(mask - reconstruct_final).mean()
-	0.0042572021484375
+	>>> np.abs(mask - close_img).mean() # doctest: +ELLIPSIS
+	0.00727836...
+	>>> np.abs(mask - reconstruct_final).mean() # doctest: +ELLIPSIS
+	0.00059502...
 
 .. topic:: **Exercise**
     :class: green
@@ -724,7 +724,7 @@ Use mathematical morphology to clean up the result::
         >>> # dependant from the gradient the segmentation is close to a voronoi
         >>> graph.data = np.exp(-graph.data/graph.data.std())
 
-        >>> labels = spectral_clustering(graph, k=4, mode='arpack')
+        >>> labels = spectral_clustering(graph, n_clusters=4, eigen_solver='arpack')
         >>> label_im = -np.ones(mask.shape)
         >>> label_im[mask] = labels
 

--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -753,7 +753,7 @@ Label connected components: ``ndimage.label``::
 
     >>> label_im, nb_labels = ndimage.label(mask)
     >>> nb_labels # how many regions?
-    23
+    16
     >>> plt.imshow(label_im)        # doctest: +ELLIPSIS
     <matplotlib.image.AxesImage object at 0x...>
 


### PR DESCRIPTION
Changes to make doctest past.
Please check.

Current version of nd scipy.ndimage has probably
changed since the tutorial was written and gives
slightly different numerical output

In particular see 699-671

Argment names in function
sklearn.cluster.spectral_clustering
have changed (line 727)

nb_labels (line 755) is now different