### PR TITLE
Py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
     - "2.7"
-    - "3.4"
+    - "3.2"
 
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - TEST_RUN_FOLDER="/tmp" # folder where the tests are run from
   matrix:
     # Ubuntu 14.04 versions
-    - DISTRIB="conda" PYTHON_VERSION="2.7" 
+    - DISTRIB="conda" PYTHON_VERSION="$TRAVIS_PYTHON_VERSION"
       NUMPY_VERSION="1.8.2" SCIPY_VERSION="0.14.0" 
       SCIKIT_LEARN_VERSION="0.15.1" MATPLOTLIB_VERSION="1.4.0"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 
+python:
+    - "2.7"
+    - "3.4"
+
 virtualenv:
   system_site_packages: true
 


### PR DESCRIPTION
The test set passes on Python 3.4 locally but due to limitations of versions with the travis+conda+site-systempackages combination I setup the .travis.yml file for Python 3.2, which passed 

https://travis-ci.org/vahtras/scipy-lecture-notes/builds/78044874

see also 
https://github.com/travis-ci/travis-ci/issues/2219#issuecomment-41804942