### PR TITLE
Issue 66: update authors list

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,8 +67,6 @@ Listed by alphabetical order
 
 - egens
 
-- emmanuelle
-
 - Andre Espaze
 
 - André Espaze
@@ -82,6 +80,8 @@ Listed by alphabetical order
 - Ralf Gommers
 
 - Emmanuelle Gouillart
+
+- Julia Gustavsen
 
 - Valentin Haenel
 
@@ -98,8 +98,6 @@ Listed by alphabetical order
 - kikocorreoso
 
 - mhemantha
-
-- mriehl
 
 - nicoguaro
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,32 +45,106 @@ Listed by alphabetical order.
 Additional Contributions
 ------------------------
 
-- Akihiro Uchida
+Listed by alphabetical order
 
-- Corey Farwell
+- arunpersaud
 
-- egens
-
-- Gert-Ludwig Ingold
-
-- Jonathan J. Helmus
-
-- kikocorreo
+- Matthew Brett
 
 - Lars Buitinck
 
-- Nicolas Pettiaux
-
-- Olav Vahtras
-
-- Olivier Verdier
+- Pierre de Buyl
 
 - Ozan Çağlayan
 
-- Pierre de Buyl
+- Adrien Chauve
+
+- Robert Cimrman
+
+- Christophe Combelles
+
+- David Cournapeau
+
+- egens
+
+- emmanuelle
+
+- Andre Espaze
+
+- André Espaze
+
+- Corey Farwell
 
 - Robert Gieseke
 
+- Philip Gillißen
+
+- Ralf Gommers
+
+- Emmanuelle Gouillart
+
+- Valentin Haenel
+
+- Pierre Haessig
+
+- Jonathan Helmus
+
+- Tarek Hoteit
+
+- Gert-Ludwig Ingold
+
+- Zbigniew Jędrzejewski-Szmek
+
+- kikocorreoso
+
+- mhemantha
+
+- mriehl
+
+- nicoguaro
+
 - Sergio Oller
 
-- Virgile Fritsch
+- Fabian Pedregosa
+
+- Tiago M. D. Pereira
+
+- Nicolas Pettiaux
+
+- Didrik Pinte
+
+- reverland
+
+- Maximilien Riehl
+
+- Nicolas Rougier
+
+- Helen Sherwood-Taylor
+
+- Simon
+
+- strpeter
+
+- Wes Turner
+
+- Akihiro Uchida
+
+- Utkarsh Upadhyay
+
+- Olav Vahtras
+
+- Gael Varoquaux
+
+- Nelle Varoquaux
+
+- Olivier Verdier
+
+- VirgileFritsch
+
+- Pauli Virtanen
+
+- Yosh Wakeham
+
+- Stefan van der Walt
+
+- yasutomo57jp

--- a/Makefile
+++ b/Makefile
@@ -113,4 +113,5 @@ epub:
 	@echo
 	@echo "Build finished. The epub file is in build/epub."
 
-
+contributors:
+	git shortlog -sn  2>&1 | awk '{print $$NF, $$0}' | sort | cut -d ' ' -f 2- | sed "s/^  *[0-9][0-9]*	/\n- /"


### PR DESCRIPTION
Created a makefile rule to list all contributors to be listed at the end of AUTHORS.rst (alphabetical order on last name)

    $ make contributors
    - arunpersaud

    - Matthew Brett

    - Lars Buitinck
    ...

Possible issues:

* Some entries are only github usernames because the account holder has not provided his or her full name
* Should names be include here which are already in the "Chapter authors" section?
* All contributors are listed, even if they only made a single commit with a spell fix. That can be discussed but I have chosen not to exclude anyone here.

/Olav