### PR TITLE
corrected rst to restore code example

### DIFF
--- a/intro/image_processing/image_processing.rst
+++ b/intro/image_processing/image_processing.rst
@@ -29,6 +29,7 @@ Changing orientation, resolution, .. ::
    :align: center
    :scale: 70
 
+::
 
     >>> plt.subplot(151)    # doctest: +ELLIPSIS
     <matplotlib.axes._subplots.AxesSubplot object at 0x...>


### PR DESCRIPTION
Following the conversion from an IPython-style to a Python-style code example, the code example ended up being interpreted as an incorrect figure caption. The code example thus effectively had disappeared. This PR corrects the problem and restores the code example.