### PR TITLE
make code example visible

### DIFF
--- a/advanced/optimizing/index.rst
+++ b/advanced/optimizing/index.rst
@@ -261,8 +261,7 @@ scipy are richer then those in numpy and should be preferred.
 We can then use this insight to :download:`optimize the previous code <demo_opt.py>`:
 
 .. literalinclude:: demo_opt.py
-   :start-line: 9
-   :end-line: 13
+   :pyobject: test
 
 .. sourcecode:: ipython
 


### PR DESCRIPTION
The `literalcode` directive does not accept the keyword `start_line`. Therefore, the code example did not appear in the output. Probably the most stable way to include the code segment is the `pyobject` keyword used in this PR.