### PR TITLE
Upgrade CC-BY 3.0 US to CC-BY 4.0 international

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -3,8 +3,8 @@ License
 
 All code and material is licensed under a 
 
-Creative Commons Attribution 3.0 United States License (CC-by)
+Creative Commons Attribution 4.0 Internatonal License (CC-by)
 
-http://creativecommons.org/licenses/by/3.0/us
+http://creativecommons.org/licenses/by/4.0/
 
 See the AUTHORS.rst file for a list of contributors.


### PR DESCRIPTION
Just a proposal to upgrade the CC-BY 3.0 United state to CC-BY 4.0 International.

I'm not quite qure what is the difference but if Creative Commons upgraded the CC-BY, maybe they detected some problem with the 3.0. Also, not quite sure about the advantage of the US version compared to the international one.
