### PR TITLE
Fix html build errors

### DIFF
--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -481,7 +481,9 @@ Main point
 **The answer** (in Numpy)
 
   - **strides**: the number of bytes to jump to find the next element
-  - 1 stride per dimension::
+  - 1 stride per dimension
+
+.. code-block:: python
 
     >>> x.strides
     (3, 1)

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -894,7 +894,7 @@ scipy provides a helper function for this purpose:
     >>> x = np.linspace(0, 3, 50)
     >>> y = f(x, 1.5, 1) + .1*np.random.normal(size=50)
 
-    >>> optimize.curve_fit(f, x, y)
+    >>> optimize.curve_fit(f, x, y) #doctest: +SKIP
     (array([ 1.51854577,  0.92665541]), array([[ 0.00037994, -0.00056796],
            [-0.00056796,  0.00123978]]))
 

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -886,8 +886,7 @@ While it is possible to construct our optimization problem ourselves,
 scipy provides a helper function for this purpose:
 :func:`scipy.optimize.curve_fit`::
 
-.. Comment to make doctest pass
-    >>> np.random.seed(0)
+    >>> np.random.seed(0) #doctest: +SKIP
 
     >>> def f(t, omega, phi):
     ...     return np.cos(omega * t + phi)

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -881,12 +881,14 @@ Curve fitting
     :target: auto_examples/plot_curve_fit.html
     :align: right
 
+.. Comment to make doctest pass
+    >>> np.random.seed(0)
+
 Least square problems occur often when fitting a non-linear to data.
 While it is possible to construct our optimization problem ourselves,
 scipy provides a helper function for this purpose:
 :func:`scipy.optimize.curve_fit`::
 
-    >>> np.random.seed(0) #doctest: +SKIP
 
     >>> def f(t, omega, phi):
     ...     return np.cos(omega * t + phi)
@@ -894,7 +896,7 @@ scipy provides a helper function for this purpose:
     >>> x = np.linspace(0, 3, 50)
     >>> y = f(x, 1.5, 1) + .1*np.random.normal(size=50)
 
-    >>> optimize.curve_fit(f, x, y) #doctest: +SKIP
+    >>> optimize.curve_fit(f, x, y)
     (array([ 1.51854577,  0.92665541]), array([[ 0.00037994, -0.00056796],
            [-0.00056796,  0.00123978]]))
 

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -90,7 +90,7 @@ This is the way to include your image and link it to the code:
 You can display the corresponding code using the ``literal-include``
 directive.
 
-.. literal-include:: examples/plot_simple.py
+.. literalinclude:: examples/plot_simple.py
 
 .. note::
 

--- a/intro/language/functions.rst
+++ b/intro/language/functions.rst
@@ -376,7 +376,9 @@ Exercises
 .. topic:: Exercise: Quicksort
     :class: green
 
-    Implement the quicksort algorithm, as defined by wikipedia::
+    Implement the quicksort algorithm, as defined by wikipedia
+
+.. parsed-literal::
 
     function quicksort(array)
         var list less, greater

--- a/intro/scipy.rst
+++ b/intro/scipy.rst
@@ -448,9 +448,7 @@ our initial guess: ::
 
 Suppose we have data sampled from ``f`` with some noise: ::
 
-.. Comment to make doctest pass
     >>> np.random.seed(42)
-
     >>> xdata = np.linspace(-10, 10, num=20)
     >>> ydata = f(xdata) + np.random.randn(xdata.size)
 

--- a/intro/scipy.rst
+++ b/intro/scipy.rst
@@ -446,9 +446,12 @@ our initial guess: ::
 
 **Curve fitting**
 
+.. Comment to make doctest pass
+    >>> np.random.seed(42)
+
 Suppose we have data sampled from ``f`` with some noise: ::
 
-    >>> np.random.seed(42)
+
     >>> xdata = np.linspace(-10, 10, num=20)
     >>> ydata = f(xdata) + np.random.randn(xdata.size)
 


### PR DESCRIPTION
These changes aim to fix the folloing errors:

    scipy-lecture-notes/advanced/advanced_numpy/index.rst:488: ERROR: Inconsistent literal block quoting.
    scipy-lecture-notes/advanced/mathematical_optimization/index.rst:890: ERROR: Unexpected indentation.
    scipy-lecture-notes/guide/index.rst:93: ERROR: Unknown directive type "literal-include". 
    scipy-lecture-notes/intro/language/functions.rst:384: ERROR: Unexpected indentation.
    scipy-lecture-notes/intro/language/functions.rst:387: ERROR: Unexpected indentation. 
    scipy-lecture-notes/intro/scipy.rst:452: ERROR: Unexpected indentation.
