### PR TITLE
Updated the broken link to PyAMG

### DIFF
--- a/advanced/scipy_sparse/other_packages.rst
+++ b/advanced/scipy_sparse/other_packages.rst
@@ -3,7 +3,7 @@ Other Interesting Packages
 
 * PyAMG
     * algebraic multigrid solvers
-    * http://code.google.com/p/pyamg
+    * https://github.com/pyamg/pyamg
 * Pysparse
     * own sparse matrix classes
     * matrix and eigenvalue problem solvers


### PR DESCRIPTION
The project PyAMG has moved to github.