### PR TITLE
Added module initialization code for python 3

### DIFF
--- a/advanced/interfacing_with_c/python_c_api/cos_module.c
+++ b/advanced/interfacing_with_c/python_c_api/cos_module.c
@@ -31,9 +31,27 @@ static PyMethodDef CosMethods[] =
 };
 
 /* module initialization */
+/* Python version 3*/
+static struct PyModuleDef cModPyDem =
+{
+    PyModuleDef_HEAD_INIT,
+    "cos_module", "Some documentation",
+    -1,
+    CosMethods
+};
 PyMODINIT_FUNC
+PyInit_cos_module(void)
+{
+    return PyModule_Create(&cModPyDem);
+}
 
+
+/* module initialization */
+/* Python version 2 */
+/*
+PyMODINIT_FUNC
 initcos_module(void)
 {
      (void) Py_InitModule("cos_module", CosMethods);
 }
+*/


### PR DESCRIPTION
I've been testing this code during a lesson and the module initialization code is for python 2. I added the code for python3 and make it the default.

Maybe a test from at least another person would be good before merge.
