### PR TITLE
Fix of the Prime Sieve example

### DIFF
--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -714,8 +714,8 @@ memory and time.
 
    .. sourcecode:: pycon
 
-       >>> N_max = int(np.sqrt(len(is_prime)))
-       >>> for j in range(2, N_max):
+       >>> N_max = int(np.sqrt(len(is_prime)-1))
+       >>> for j in range(2, N_max+1):
        ...     is_prime[2*j::j] = False
 
    * Skim through ``help(np.nonzero)``, and print the prime numbers


### PR DESCRIPTION
Without this fix, if you would replace the number 100 by the number 5 in the line
```python
is_prime = np.ones((100,), dtype=bool)
```
you would get the wrong result that 4 is a prime number!

(More generally, this would occur everytime you take any number of the form $p^2+1$, where $p$ is some prime number.)