### PR TITLE
add conda install of libgfortran=1

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -70,6 +70,7 @@ create_new_conda_env() {
     echo "conda requirements string: $REQUIREMENTS"
     conda create -n testenv --yes $REQUIREMENTS
     source activate testenv
+    conda install --yes libgfortran=1
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         # Make sure that MKL is used


### PR DESCRIPTION
The dependence of NumPy on libgfortran has changed in conda, see
https://github.com/conda/conda/issues/2177