### PR TITLE
Advanced numpy updates

### DIFF
--- a/advanced/advanced_numpy/examples/mandel-answer.pyx
+++ b/advanced/advanced_numpy/examples/mandel-answer.pyx
@@ -39,25 +39,14 @@ cdef void mandel_single_point(double complex *z_in,
 
 # Boilerplate Cython definitions
 #
-# You don't really need to read this part, it just pulls in
-# stuff from the Numpy C headers.
-# ----------------------------------------------------------
+#  pulls definitions from the Numpy C headers.
+# --------------------------------------------
 
-cdef extern from "numpy/arrayobject.h":
-    void import_array()
-    ctypedef int npy_intp
-    cdef enum NPY_TYPES:
-        NPY_CDOUBLE
-
-cdef extern from "numpy/ufuncobject.h":
-    void import_ufunc()
-    ctypedef void (*PyUFuncGenericFunction)(char**, npy_intp*, npy_intp*, void*)
-    object PyUFunc_FromFuncAndData(PyUFuncGenericFunction* func, void** data,
-        char* types, int ntypes, int nin, int nout,
-        int identity, char* name, char* doc, int c)
-
-    void PyUFunc_DD_D(char**, npy_intp*, npy_intp*, void*)
-
+from numpy cimport import_array, import_ufunc 
+from numpy cimport (PyUFunc_FromFuncAndData,
+                    PyUFuncGenericFunction)
+from numpy cimport NPY_CDOUBLE
+from numpy cimport PyUFunc_DD_D
 
 # Required module initialization
 # ------------------------------

--- a/advanced/advanced_numpy/examples/mandel-answer.pyx
+++ b/advanced/advanced_numpy/examples/mandel-answer.pyx
@@ -39,8 +39,8 @@ cdef void mandel_single_point(double complex *z_in,
 
 # Boilerplate Cython definitions
 #
-#  pulls definitions from the Numpy C headers.
-# --------------------------------------------
+# Pulls definitions from the Numpy C headers.
+# -------------------------------------------
 
 from numpy cimport import_array, import_ufunc 
 from numpy cimport (PyUFunc_FromFuncAndData,

--- a/advanced/advanced_numpy/examples/mandel.pyx
+++ b/advanced/advanced_numpy/examples/mandel.pyx
@@ -58,43 +58,34 @@ cdef void mandel_single_point(double complex *z_in,
 
 # Boilerplate Cython definitions
 #
-# The litany below is particularly long, but you don't really need to
-# read this part; it just pulls in stuff from the Numpy C headers.
-# ----------------------------------------------------------
+#  pulls definitions from the Numpy C headers.
+# --------------------------------------------
 
-cdef extern from "numpy/arrayobject.h":
-    void import_array()
-    ctypedef int npy_intp
-    cdef enum NPY_TYPES:
-        NPY_DOUBLE
-        NPY_CDOUBLE
-        NPY_LONG
+from numpy cimport import_array, import_ufunc 
+from numpy cimport (PyUFunc_FromFuncAndData,
+                    PyUFuncGenericFunction)
+from numpy cimport NPY_CDOUBLE, NP_DOUBLE, NPY_LONG
 
-cdef extern from "numpy/ufuncobject.h":
-    void import_ufunc()
-    ctypedef void (*PyUFuncGenericFunction)(char**, npy_intp*, npy_intp*, void*)
-    object PyUFunc_FromFuncAndData(PyUFuncGenericFunction* func, void** data,
-        char* types, int ntypes, int nin, int nout,
-        int identity, char* name, char* doc, int c)
+# Import all pre-defined loop functions
+# you won't need all of them - keep the relevant ones
 
-    # List of pre-defined loop functions
-
-    void PyUFunc_f_f_As_d_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_d_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_f_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_g_g(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_F_F_As_D_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_F_F(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_D_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_G_G(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_ff_f_As_dd_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_ff_f(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_dd_d(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_gg_g(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_FF_F_As_DD_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_DD_D(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_FF_F(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
-    void PyUFunc_GG_G(char** args, npy_intp* dimensions, npy_intp* steps, void* func)
+from numpy cimport (
+    PyUFunc_f_f_As_d_d,
+    PyUFunc_d_d,
+    PyUFunc_f_f,
+    PyUFunc_g_g,
+    PyUFunc_F_F_As_D_D,
+    PyUFunc_F_F,
+    PyUFunc_D_D,
+    PyUFunc_G_G,
+    PyUFunc_ff_f_As_dd_d,
+    PyUFunc_ff_f,
+    PyUFunc_dd_d,
+    PyUFunc_gg_g,
+    PyUFunc_FF_F_As_DD_D,
+    PyUFunc_DD_D,
+    PyUFunc_FF_F,
+    PyUFunc_GG_G)
 
 
 # Required module initialization

--- a/advanced/advanced_numpy/examples/mandel.pyx
+++ b/advanced/advanced_numpy/examples/mandel.pyx
@@ -58,8 +58,8 @@ cdef void mandel_single_point(double complex *z_in,
 
 # Boilerplate Cython definitions
 #
-#  pulls definitions from the Numpy C headers.
-# --------------------------------------------
+# Pulls definitions from the Numpy C headers.
+# -------------------------------------------
 
 from numpy cimport import_array, import_ufunc 
 from numpy cimport (PyUFunc_FromFuncAndData,

--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -1148,7 +1148,16 @@ Generalized ufuncs
 
 * g-ufuncs are in Numpy already ...
 * new ones can be created with ``PyUFunc_FromFuncAndDataAndSignature``
-* ... but we don't ship with public g-ufuncs, except for testing, ATM
+* most linear-algebra functions are implemented as g-ufuncs to enable working
+  with stacked arrays
+
+>>> import numpy as np
+>>> np.linalg.det(np.random.rand(3, 5, 5))
+array([-0.01404366,  0.02263015, -0.01137558])
+>>> np.linalg._umath_linalg.det.signature
+'(m,m)->()'
+
+* we also ship with a few g-ufuncs for testing, ATM
 
 >>> import numpy.core.umath_tests as ut
 >>> ut.matrix_multiply.signature
@@ -1159,7 +1168,7 @@ Generalized ufuncs
 >>> ut.matrix_multiply(x, y).shape
 (10, 2, 5)
 
-* the last two dimensions became *core dimensions*,
+* in both examples the last two dimensions became *core dimensions*,
   and are modified as per the *signature*
 * otherwise, the g-ufunc operates "elementwise"
 

--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -1149,24 +1149,24 @@ Generalized ufuncs
 * g-ufuncs are in Numpy already ...
 * new ones can be created with ``PyUFunc_FromFuncAndDataAndSignature``
 * most linear-algebra functions are implemented as g-ufuncs to enable working
-  with stacked arrays
+  with stacked arrays::
 
->>> import numpy as np
->>> np.linalg.det(np.random.rand(3, 5, 5))
-array([ 0.00965823, -0.13344729,  0.04583961])
->>> np.linalg._umath_linalg.det.signature
-'(m,m)->()'
+    >>> import numpy as np
+    >>> np.linalg.det(np.random.rand(3, 5, 5))
+    array([ 0.00965823, -0.13344729,  0.04583961])
+    >>> np.linalg._umath_linalg.det.signature
+    '(m,m)->()'
 
-* we also ship with a few g-ufuncs for testing, ATM
+* we also ship with a few g-ufuncs for testing, ATM::
 
->>> import numpy.core.umath_tests as ut
->>> ut.matrix_multiply.signature
-'(m,n),(n,p)->(m,p)'
-
->>> x = np.ones((10, 2, 4))
->>> y = np.ones((10, 4, 5))
->>> ut.matrix_multiply(x, y).shape
-(10, 2, 5)
+    >>> import numpy.core.umath_tests as ut
+    >>> ut.matrix_multiply.signature
+    '(m,n),(n,p)->(m,p)'
+    
+    >>> x = np.ones((10, 2, 4))
+    >>> y = np.ones((10, 4, 5))
+    >>> ut.matrix_multiply(x, y).shape
+    (10, 2, 5)
 
 * in both examples the last two dimensions became *core dimensions*,
   and are modified as per the *signature*

--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -1153,7 +1153,7 @@ Generalized ufuncs
 
 >>> import numpy as np
 >>> np.linalg.det(np.random.rand(3, 5, 5))
-array([-0.01404366,  0.02263015, -0.01137558])
+array([ 0.00965823, -0.13344729,  0.04583961])
 >>> np.linalg._umath_linalg.det.signature
 '(m,m)->()'
 
@@ -1553,7 +1553,7 @@ Good bug report
     it fails with a cryptic error message::
 
         >>> np.random.permutation(12)
-        array([ 6, 11,  4, 10,  2,  8,  1,  7,  9,  3,  0,  5])
+        array([11,  5,  8,  4,  6,  1,  9,  3,  7,  2, 10,  0])
         >>> np.random.permutation(12.)
         Traceback (most recent call last):
           File "<stdin>", line 1, in <module>


### PR DESCRIPTION
Updates to Advanced NumPy chapter:

* creating ufuncs: NumPy ships with Cython definitions, so no more need to pull stuff from NumPy C-headers
* generalised ufuncs: NumPy >= 1.8 ships with public g-ufuncs in linalg module