### PR TITLE
Add documentation generation on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,46 @@
+machine:
+  environment:
+    PATH: /home/ubuntu/miniconda/bin:$PATH
+
+dependencies:
+  pre:
+    # Get rid of existing virtualenvs on circle ci as they conflict with conda.
+    # Trick found here:
+    # https://discuss.circleci.com/t/disable-autodetection-of-project-or-application-of-python-venv/235/10
+    - cd && rm -rf ~/.pyenv && rm -rf ~/virtualenvs
+    # We need to remove conflicting texlive packages.
+    - sudo -E apt-get -yq remove texlive-binaries --purge
+    # Installing required packages for `make -C doc check command` to work.
+    - sudo -E apt-get -yq update
+    - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra
+
+  override:
+    - cd ~/scipy-lecture-notes
+    - source continuous_integration/install.sh:
+        environment:
+            DISTRIB: "conda"
+            PYTHON_VERSION: "2.7"
+            NUMPY_VERSION: "1.9"
+            SCIPY_VERSION: "0.14.0"
+            SCIKIT_LEARN_VERSION: "0.16.1"
+            MATPLOTLIB_VERSION: "1.4.0"
+            SCIKIT_IMAGE_VERSION: "0.10.1"
+            SYMPY_VERSION: "0.7.5"
+            STATSMODELS_VERSION: "0.5"
+            SEABORN_VERSION: "0.6"
+            PANDAS_VERSION: "0.15"
+    - conda install sphinx coverage pillow -y -n testenv --quiet
+    - source activate testenv && python continuous_integration/show-python-packages-versions.py
+
+test:
+  override:
+    # Tests are disabled for now because they trigger errors that are not understood
+    # - make clean test
+    - source continuous_integration/circle_ci_test_doc.sh
+    # workaround - make html returns 0 even if examples fail to build
+    - cat ~/log.txt && if grep -q "Traceback (most recent call last):" ~/log.txt; then false; else true; fi
+
+general:
+  artifacts:
+    - "build/html"
+    - "~/log.txt"

--- a/continuous_integration/circle_ci_test_doc.sh
+++ b/continuous_integration/circle_ci_test_doc.sh
@@ -1,0 +1,11 @@
+#!bin/bash
+
+# on circle ci, each command run with it's own execution context so we have to
+# activate the conda testenv on a per command basis. That's why we put calls to
+# python (conda) in a dedicated bash script and we activate the conda testenv
+# here.
+source activate testenv
+
+# pipefail is necessary to propagate exit codes
+set -o pipefail && make html 2>&1 | tee ~/log.txt
+

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -27,7 +27,7 @@ create_new_venv() {
 
 print_conda_requirements() {
     # Echo a conda requirement string for example
-    # "pip nose python='.7.3 scikit-learn=*". It has a hardcoded
+    # "pip nose python='2.7.3 scikit-learn=*". It has a hardcoded
     # list of possible packages to install and looks at _VERSION
     # environment variables to know whether to install a given package and
     # if yes which version to install. For example:
@@ -52,30 +52,28 @@ print_conda_requirements() {
 }
 
 create_new_conda_env() {
-    # Deactivate the travis-provided virtual environment and setup a
-    # conda-based environment instead
-    deactivate
+    # Skip Travis related code on circle ci.
+    if [ -z $CIRCLECI ]; then
+        # Deactivate the travis-provided virtual environment and setup a
+        # conda-based environment instead
+        deactivate
+    fi
 
     # Use the miniconda installer for faster download / install of conda
     # itself
-    if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh \
-        -O miniconda.sh
-    else
-        wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-        -O miniconda.sh
-    fi
+    wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh \
+         -O miniconda.sh
     bash miniconda.sh -b -p $HOME/miniconda
-    export PATH=/home/travis/miniconda/bin:$PATH
+    export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
 
     # Configure the conda environment and put it in the path using the
     # provided versions
     REQUIREMENTS=$(print_conda_requirements)
     echo "conda requirements string: $REQUIREMENTS"
-    conda create -n testenv --yes $REQUIREMENTS
+    conda create -n testenv --quiet --yes $REQUIREMENTS
     source activate testenv
-    conda install --yes python=$TRAVIS_PYTHON_VERSION libgfortran=1
+    conda install --yes libgfortran=1
 
     if [[ "$INSTALL_MKL" == "true" ]]; then
         # Make sure that MKL is used


### PR DESCRIPTION
Some modifications necessary in continuous_integration/install.sh to make it compatible with both Travis and CircleCI.

Also for now tests are not run on CircleCI because there are plenty of errors I don't understand.

Fixes #244.