### PR TITLE
Adapt examples to MPL 1.5

### DIFF
--- a/intro/matplotlib/examples/plot_bar.py
+++ b/intro/matplotlib/examples/plot_bar.py
@@ -19,11 +19,20 @@ plt.xticks(())
 plt.ylim(-1, 1)
 plt.yticks(())
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Bar Plot:              plt.bar(...)\n",
       horizontalalignment='left',
       verticalalignment='top',
       size='xx-large',
-      bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
       transform=plt.gca().transAxes)
 
 plt.text(-0.05, 1.01, "\n\n   Make a bar plot with rectangles ",

--- a/intro/matplotlib/examples/plot_boxplot.py
+++ b/intro/matplotlib/examples/plot_boxplot.py
@@ -24,11 +24,20 @@ plt.boxplot(Y)
 
 plt.xticks(()), plt.yticks(())
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Box Plot:   plt.boxplot(...)\n",
         horizontalalignment='left',
         verticalalignment='top',
         size='xx-large',
-        bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
         transform=axes.transAxes)
 
 plt.text(-0.05, 1.01, " Make a box and whisker plot ",

--- a/intro/matplotlib/examples/plot_contour.py
+++ b/intro/matplotlib/examples/plot_contour.py
@@ -24,11 +24,20 @@ plt.clabel(C, inline=1, fontsize=10)
 plt.xticks(())
 plt.yticks(())
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Contour Plot: plt.contour(..)\n",
       horizontalalignment='left',
       verticalalignment='top',
       size='xx-large',
-      bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
       transform=plt.gca().transAxes)
 
 plt.text(-0.05, 1.01, "\n\n  Draw contour lines and filled contours ",

--- a/intro/matplotlib/examples/plot_grid.py
+++ b/intro/matplotlib/examples/plot_grid.py
@@ -24,11 +24,20 @@ axes.grid(which='minor', axis='y', linewidth=0.25, linestyle='-', color='0.75')
 axes.set_xticklabels([])
 axes.set_yticklabels([])
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Grid:                  plt.grid(...)\n",
           horizontalalignment='left',
           verticalalignment='top',
           size='xx-large',
-          bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
           transform=axes.transAxes)
 
 plt.text(-0.05, 1.01, "\n\n    Draw ticks and grid ",

--- a/intro/matplotlib/examples/plot_imshow.py
+++ b/intro/matplotlib/examples/plot_imshow.py
@@ -20,11 +20,20 @@ plt.imshow(Z, interpolation='nearest', cmap='bone', origin='lower')
 plt.xticks(())
 plt.yticks(())
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Imshow:       plt.imshow(...)\n",
         horizontalalignment='left',
         verticalalignment='top',
         size='xx-large',
-        bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
         transform=plt.gca().transAxes)
 
 plt.text(-0.05, 1.01, "\n\n   Display an image to current axes ",

--- a/intro/matplotlib/examples/plot_multiplot.py
+++ b/intro/matplotlib/examples/plot_multiplot.py
@@ -11,11 +11,20 @@ ax = plt.subplot(2, 1, 1)
 ax.set_xticklabels([])
 ax.set_yticklabels([])
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .72),
+                            width=.66, height=.34, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Multiplot:     plt.subplot(...)\n",
       horizontalalignment='left',
       verticalalignment='top',
       size='xx-large',
-      bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
       transform=ax.transAxes)
 plt.text(-0.05, 1.01, "\n\n    Plot several plots at once ",
       horizontalalignment='left',

--- a/intro/matplotlib/examples/plot_pie.py
+++ b/intro/matplotlib/examples/plot_pie.py
@@ -22,11 +22,20 @@ plt.ylim(-1.5 * r, 1.5 * r)
 plt.xticks(())
 plt.yticks(())
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Pie Chart:           plt.pie(...)\n",
         horizontalalignment='left',
         verticalalignment='top',
         size='xx-large',
-        bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
         transform=plt.gca().transAxes)
 
 plt.text(-0.05, 1.01, "\n\n   Make a pie chart of an array ",

--- a/intro/matplotlib/examples/plot_plot.py
+++ b/intro/matplotlib/examples/plot_plot.py
@@ -18,11 +18,20 @@ plt.xticks(())
 plt.ylim(-1.2, 1.2)
 plt.yticks(())
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Regular Plot:      plt.plot(...)\n",
         horizontalalignment='left',
         verticalalignment='top',
         size='xx-large',
-        bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
         transform=plt.gca().transAxes)
 
 plt.text(-0.05, 1.01, "\n\n   Plot lines and/or markers ",

--- a/intro/matplotlib/examples/plot_plot3d-2.py
+++ b/intro/matplotlib/examples/plot_plot3d-2.py
@@ -17,12 +17,13 @@ plt.xticks(())
 plt.yticks(())
 ax.set_zticks(())
 
-ax.text2D(-0.05, 1.05, " 3D plots \n\n",
+
+ax.text2D(-0.05, 1.05, " 3D plots             \n",
           horizontalalignment='left',
           verticalalignment='top',
+          bbox=dict(facecolor='white', alpha=1.0),
           family='Lint McCree Intl BB',
           size='x-large',
-          bbox=dict(facecolor='white', alpha=1.0, width=350,height=60),
           transform=plt.gca().transAxes)
 
 ax.text2D(-0.05, .975, " Plot 2D or 3D data",

--- a/intro/matplotlib/examples/plot_plot3d.py
+++ b/intro/matplotlib/examples/plot_plot3d.py
@@ -24,11 +24,11 @@ plt.xticks(())
 plt.yticks(())
 ax.set_zticks(())
 
-ax.text2D(0.05, .93, " 3D plots \n",
+ax.text2D(0.05, .93, " 3D plots             \n",
           horizontalalignment='left',
           verticalalignment='top',
           size='xx-large',
-          bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
+          bbox=dict(facecolor='white', alpha=1.0),
           transform=plt.gca().transAxes)
 
 ax.text2D(0.05, .87, " Plot 2D or 3D data",

--- a/intro/matplotlib/examples/plot_polar.py
+++ b/intro/matplotlib/examples/plot_polar.py
@@ -22,12 +22,14 @@ for r, bar in zip(radii, bars):
 plt.gca().set_xticklabels([])
 plt.gca().set_yticklabels([])
 
-plt.text(-0.2, 1.02, " Polar Axis\n",
+
+plt.text(-0.2, 1.02, " Polar Axis                  \n",
       horizontalalignment='left',
       verticalalignment='top',
       size='xx-large',
-      bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
+      bbox=dict(facecolor='white', alpha=1.0),
       transform=plt.gca().transAxes)
+
 plt.text(-0.2, 1.01, "\n\n Plot anything using polar axis ",
       horizontalalignment='left',
       verticalalignment='top',

--- a/intro/matplotlib/examples/plot_quiver.py
+++ b/intro/matplotlib/examples/plot_quiver.py
@@ -22,11 +22,20 @@ plt.xticks(())
 plt.ylim(-1, n)
 plt.yticks(())
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Quiver Plot:    plt.quiver(...)\n",
       horizontalalignment='left',
       verticalalignment='top',
       size='xx-large',
-      bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
       transform=plt.gca().transAxes)
 
 plt.text(-0.05, 1.01, "\n\n    Plot a 2-D field of arrows ",
@@ -34,5 +43,6 @@ plt.text(-0.05, 1.01, "\n\n    Plot a 2-D field of arrows ",
       verticalalignment='top',
       size='large',
       transform=plt.gca().transAxes)
+
 
 plt.show()

--- a/intro/matplotlib/examples/plot_scatter.py
+++ b/intro/matplotlib/examples/plot_scatter.py
@@ -20,11 +20,20 @@ plt.xticks(())
 plt.ylim(-1.5, 1.5)
 plt.yticks(())
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Scatter Plot:  plt.scatter(...)\n",
       horizontalalignment='left',
       verticalalignment='top',
       size='xx-large',
-      bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
       transform=plt.gca().transAxes)
 
 plt.text(-0.05, 1.01, "\n\n   Make a scatter plot of x versus y ",

--- a/intro/matplotlib/examples/plot_text.py
+++ b/intro/matplotlib/examples/plot_text.py
@@ -28,11 +28,20 @@ for i in range(24):
     plt.text(x, y, eq, ha='center', va='center', color="#11557c", alpha=alpha,
          transform=plt.gca().transAxes, fontsize=size, clip_on=True)
 
+
+# Add a title and a box around it
+from matplotlib.patches import FancyBboxPatch
+ax = plt.gca()
+ax.add_patch(FancyBboxPatch((-0.05, .87),
+                            width=.66, height=.165, clip_on=False,
+                            boxstyle="square,pad=0", zorder=3,
+                            facecolor='white', alpha=1.0,
+                            transform=plt.gca().transAxes))
+
 plt.text(-0.05, 1.02, " Text:                   plt.text(...)\n",
         horizontalalignment='left',
         verticalalignment='top',
         size='xx-large',
-        bbox=dict(facecolor='white', alpha=1.0, width=400, height=65),
         transform=plt.gca().transAxes)
 
 plt.text(-0.05, 1.01, "\n\n     Draw any kind of text ",


### PR DESCRIPTION
There is value is having the examples run also on more recent MPL versions, as this is more likely to be what users have. They should still run well on older versions.

The changes are only in examples that are actually used to generate figures, but not as real examples. They make code a bit more complicated, but I couldn't adapt to MPL 1.5 without that.