### PR TITLE
Fix Travis Python 3 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 language: python
 
-python:
-  - "2.7"
-  - "3.4"
-
-virtualenv:
-  system_site_packages: false
-
 notifications:
   email: false
 
 env:
   matrix:
     # Ubuntu 14.04 versions
-    - DISTRIB="conda" PYTHON_VERSION="$TRAVIS_PYTHON_VERSION"
+    - DISTRIB="conda" PYTHON_VERSION="2.7"
+      NUMPY_VERSION="1.9" SCIPY_VERSION="0.14.0"
+      SCIKIT_LEARN_VERSION="0.16.1" MATPLOTLIB_VERSION="1.4.0"
+      SCIKIT_IMAGE_VERSION="0.10.1" SYMPY_VERSION="0.7.5"
+      STATSMODELS_VERSION="0.5" SEABORN_VERSION="0.6"
+      PANDAS_VERSION="0.15"
+    - DISTRIB="conda" PYTHON_VERSION="3.4"
       NUMPY_VERSION="1.9" SCIPY_VERSION="0.14.0"
       SCIKIT_LEARN_VERSION="0.16.1" MATPLOTLIB_VERSION="1.4.0"
       SCIKIT_IMAGE_VERSION="0.10.1" SYMPY_VERSION="0.7.5"


### PR DESCRIPTION
Using environment variables, as PYTHON_VERSION="$TRAVIS_PYTHON_VERSION"
does not seem to work.

While I was at it, I removed the virtualenv section which is not needed.

Build from master showing that Python 2.7 is used in the Python 3.4 build:
https://travis-ci.org/scipy-lectures/scipy-lecture-notes/jobs/155856706#L565

Build from my branch showing that Python 3.4 is used in the Python 3.4 build (as it should be):
https://travis-ci.org/lesteve/scipy-lecture-notes/jobs/155877711#L562