### PR TITLE
Another Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ dist: trusty
 sudo: required
 language: python
 
-python:
-  - "2.7"
-  - "3.4"
-
 virtualenv:
   system_site_packages: false
 
@@ -13,14 +9,17 @@ notifications:
   email: false
 
 env:
-  matrix:
+  global:
     # Ubuntu 14.04 versions
-    - DISTRIB="conda" PYTHON_VERSION="$TRAVIS_PYTHON_VERSION"
+    - DISTRIB="conda"
       NUMPY_VERSION="1.9" SCIPY_VERSION="0.14.0"
       SCIKIT_LEARN_VERSION="0.16.1" MATPLOTLIB_VERSION="1.4.0"
       SCIKIT_IMAGE_VERSION="0.10.1" SYMPY_VERSION="0.7.5"
       STATSMODELS_VERSION="0.5" SEABORN_VERSION="0.6"
       PANDAS_VERSION="0.15"
+  matrix:
+    - PYTHON_VERSION=2.7
+    - PYTHON_VERSION=3.4
 
 before_install:
     - sudo apt-get install texlive texlive-latex-extra

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: required
 language: python
 
 python:


### PR DESCRIPTION
This partly revokes some changes I made previously. In the latest commit python2 was installed in both runs (see logs) because of recent adapting to CircleCI and because TRAVIS_PYTHON_VERSION was not expanded as I thought it would. Now the env block in .travis.yml contains to subblocks: *global* for the library versions common for all runs and *matrix* defining two Python versions for two consecutive runs.


The default ubuntu version is 12.04LTS, adding dist:trusty to get a newer OS 14.04LTS (no support for 16.04LTS yet)