### PR TITLE
Mayavi example images are flipped

### DIFF
--- a/packages/3d_plotting/index.rst
+++ b/packages/3d_plotting/index.rst
@@ -416,7 +416,7 @@ Different sources: scatters and fields
     :scale: 90
 
 ================================================= ==========================================
-|structured|                                      |unstructured|                
+|unstructured|                                    |structured|                
 ================================================= ==========================================
 Unstructured and unconnected data: a **scatter**  Structured and connected data: a **field**
 


### PR DESCRIPTION
I flipped the images, structured and unstructed were mixed up.