### PR TITLE
Changing random_intergers() to randint()

### DIFF
--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -115,7 +115,7 @@ For large data, use ``np.memmap`` for memory mapping::
 Working on a list of image files ::
 
     >>> for i in range(10):
-    ...     im = np.random.random_integers(0, 255, 10000).reshape((100, 100))
+    ...     im = np.random.randint(0, 256, 10000).reshape((100, 100))
     ...     misc.imsave('random_%02d.png' % i, im)
     >>> from glob import glob
     >>> filelist = glob('random*.png')

--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -748,7 +748,7 @@ Using boolean masks
 .. sourcecode:: pycon
 
     >>> np.random.seed(3)
-    >>> a = np.random.random_integers(0, 20, 15)
+    >>> a = np.random.randint(0, 21, 15)
     >>> a
     array([10,  3,  8,  0, 19, 10, 11,  9, 10,  6,  0, 20, 12,  7, 14])
     >>> (a % 3 == 0)

--- a/intro/numpy/operations.rst
+++ b/intro/numpy/operations.rst
@@ -404,7 +404,7 @@ Other reductions
   .. sourcecode:: pycon
 
    >>> t = np.arange(t_max)
-   >>> steps = 2 * np.random.random_integers(0, 1, (n_stories, t_max)) - 1
+   >>> steps = 2 * np.random.randint(0, 1 + 1, (n_stories, t_max)) - 1 # +1 because the high value is exclusive
    >>> np.unique(steps) # Verification: all steps are 1 or -1
    array([-1,  1])
 

--- a/pyplots/numpy_intro_5.py
+++ b/pyplots/numpy_intro_5.py
@@ -7,7 +7,7 @@ t_max = 200      # time during which we follow the walker
 # We randomly choose all the steps 1 or -1 of the walk
 
 t = np.arange(t_max)
-steps = 2 * np.random.random_integers(0, 1, (n_stories, t_max)) - 1
+steps = 2 * np.random.randint(0, 2, (n_stories, t_max)) - 1
 print np.unique(steps) # Verification: all steps are 1 or -1
 # [-1,  1]
 


### PR DESCRIPTION
np.random.random_integers() is depricated in numpy 1.11, we better use np.random.randint() instead.
