### PR TITLE
2.1.2 - Plural inconsistency fix

### DIFF
--- a/advanced/advanced_python/index.rst
+++ b/advanced/advanced_python/index.rst
@@ -411,8 +411,8 @@ Decorators
 .. >>> print(A)
 .. None
 
-Since a function or a class are objects, they can be passed
-around. Since they are mutable objects, they can be modified.  The act
+Since functions and classes are objects, they can be passed
+around. Since they are mutable objects, they can be modified. The act
 of altering a function or class object after it has been constructed
 but before is is bound to its name is called decorating.
 


### PR DESCRIPTION
There was inconsistency as far as usage of singular vs plural ("a function or a class are" -> "functions and classes are", since the rest of the paragraph uses it as plural). Also removed an extra space