### PR TITLE
[MRG] Fix plot_face_tv_denoise.py with skimage >= 0.12

### DIFF
--- a/advanced/image_processing/examples/plot_face_tv_denoise.py
+++ b/advanced/image_processing/examples/plot_face_tv_denoise.py
@@ -9,7 +9,11 @@ import numpy as np
 import scipy
 import scipy.misc
 import matplotlib.pyplot as plt
-from skimage.filter import denoise_tv_chambolle
+try:
+    from skimage.restoration import denoise_tv_chambolle
+except ImportError:
+    # skimage < 0.12
+    from skimage.filters import denoise_tv_chambolle
 
 f = scipy.misc.face(gray=True)
 f = f[230:290, 220:320]


### PR DESCRIPTION
From the [0.12 release notes](https://github.com/scikit-image/scikit-image/blob/master/doc/release/release_0.12.rst#api-changes):

> skimage.filters.denoise_* have moved to skimage.restoration.denoise_*.