### PR TITLE
Shorten ellipsis for the output of np.array?

### DIFF
--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -110,7 +110,7 @@ NumPy Reference documentation
      Help on built-in function array in module numpy.core.multiarray:
      <BLANKLINE>
      array(...)
-         array(object, dtype=None, copy=True, order=None, subok=False, ...
+         array(object, dtype=None, ...
 
 
 - Looking for something:


### PR DESCRIPTION
It is very sensitive to the version of numpy, etc, and will fail even when CI
testing is good.