### PR TITLE
Unflatten sympy namespace

### DIFF
--- a/packages/sympy.rst
+++ b/packages/sympy.rst
@@ -45,14 +45,14 @@ First Steps with SymPy
 Using SymPy as a calculator
 ---------------------------
 
-SymPy defines three numerical types: Real, Rational and Integer.
+SymPy defines three numerical types: ``Real``, ``Rational`` and ``Integer``.
 
 The Rational class represents a rational number as a pair of two
-Integers: the numerator and the denominator, so Rational(1,2)
-represents 1/2, Rational(5,2) 5/2 and so on::
+Integers: the numerator and the denominator, so ``Rational(1,2)``
+represents 1/2, ``Rational(5,2)`` 5/2 and so on::
 
-    >>> from sympy import *
-    >>> a = Rational(1,2)
+    >>> import sympy as sym
+    >>> a = sym.Rational(1,2)
 
     >>> a
     1/2
@@ -62,27 +62,28 @@ represents 1/2, Rational(5,2) 5/2 and so on::
 
 SymPy uses mpmath in the background, which makes it possible to
 perform computations using arbitrary-precision arithmetic. That
-way, some special constants, like e, pi, oo (Infinity), are treated as
+way, some special constants, like :math:`e`, :math:`pi`, :math:`oo` (Infinity), 
+are treated as
 symbols and can be evaluated with arbitrary precision::
 
-    >>> pi**2
+    >>> sym.pi**2
       2
     pi 
 
-    >>> pi.evalf()
+    >>> sym.pi.evalf()
     3.14159265358979
 
-    >>> (pi + exp(1)).evalf()
+    >>> (sym.pi + sym.exp(1)).evalf()
     5.85987448204884
 
-as you see, evalf evaluates the expression to a floating-point number.
+as you see, ``evalf`` evaluates the expression to a floating-point number.
 
 There is also a class representing mathematical infinity, called
 ``oo``::
 
-    >>> oo > 99999
+    >>> sym.oo > 99999
     True
-    >>> oo + 1
+    >>> sym.oo + 1
     oo
 
 
@@ -99,9 +100,8 @@ Symbols
 In contrast to other Computer Algebra Systems, in SymPy you have to declare
 symbolic variables explicitly::
 
-    >>> from sympy import *
-    >>> x = Symbol('x')
-    >>> y = Symbol('y')
+    >>> x = sym.Symbol('x')
+    >>> y = sym.Symbol('y')
 
 Then you can manipulate them::
 
@@ -112,15 +112,15 @@ Then you can manipulate them::
            2
     (x + y) 
 
-Symbols can now be manipulated using some of python operators: +, -, \*, \*\* 
-(arithmetic), &, `|`, ~ , >>, << (boolean).
+Symbols can now be manipulated using some of python operators: ``+``, ``-`, 
+``*``, ``**`` (arithmetic), &, `|`, ~ , >>, << (boolean).
 
 
 .. topic:: **Printing**
 
    Here we use the following setting for printing
 
-    >>> sympy.init_printing(use_unicode=False, wrap_line=True)
+    >>> sym.init_printing(use_unicode=False, wrap_line=True)
 
 
 
@@ -136,7 +136,7 @@ Expand
 Use this to expand an algebraic expression. It will try to denest
 powers and multiplications::
 
-    >>> expand((x + y)**3)
+    >>> sym.expand((x + y)**3)
      3      2          2    3
     x  + 3*x *y + 3*x*y  + y 
     >>> 3*x*y**2 + 3*y*x**2 + x**3 + y**3
@@ -146,14 +146,14 @@ powers and multiplications::
 
 Further options can be given in form on keywords::
 
-    >>> expand(x + y, complex=True)
+    >>> sym.expand(x + y, complex=True)
     re(x) + re(y) + I*im(x) + I*im(y)
-    >>> I*im(x) + I*im(y) + re(x) + re(y)
+    >>> sym.I*sym.im(x) + sym.I*sym.im(y) + sym.re(x) + sym.re(y)
     re(x) + re(y) + I*im(x) + I*im(y)
 
-    >>> expand(cos(x + y), trig=True)
+    >>> sym.expand(sym.cos(x + y), trig=True)
     -sin(x)*sin(y) + cos(x)*cos(y)
-    >>> cos(x)*cos(y) - sin(x)*sin(y)
+    >>> sym.cos(x)*sym.cos(y) - sym.sin(x)*sym.sin(y)
     -sin(x)*sin(y) + cos(x)*cos(y)
 
 Simplify
@@ -162,14 +162,14 @@ Simplify
 Use simplify if you would like to transform an expression into a
 simpler form::
 
-    >>> simplify((x + x*y) / x)
+    >>> sym.simplify((x + x*y) / x)
     y + 1
 
 
 Simplification is a somewhat vague term, and more precises
-alternatives to simplify exists: powsimp (simplification of
-exponents), trigsimp (for trigonometric expressions) , logcombine,
-radsimp, together.
+alternatives to simplify exists: ``powsimp`` (simplification of
+exponents), ``trigsimp`` (for trigonometric expressions) , ``logcombine``,
+``radsimp``, together.
 
 .. topic:: **Exercises**
    :class: green
@@ -184,22 +184,22 @@ Calculus
 Limits
 ------
 
-Limits are easy to use in SymPy, they follow the syntax limit(function,
-variable, point), so to compute the limit of :math:`f(x)` as :math:`x \rightarrow 0`, you would issue
-limit(f, x, 0)::
+Limits are easy to use in SymPy, they follow the syntax ``limit(function,
+variable, point)``, so to compute the limit of :math:`f(x)` as 
+:math:`x \rightarrow 0`, you would issue ``limit(f, x, 0)``::
 
-   >>> limit(sin(x)/x, x, 0)
+   >>> sym.limit(sym.sin(x)/x, x, 0)
    1
 
 you can also calculate the limit at infinity::
 
-   >>> limit(x, x, oo)
+   >>> sym.limit(x, x, sym.oo)
    oo
 
-   >>> limit(1/x, x, oo)
+   >>> sym.limit(1/x, x, sym.oo)
    0
 
-   >>> limit(x**x, x, 0)
+   >>> sym.limit(x**x, x, 0)
    1
 
 
@@ -211,30 +211,30 @@ Differentiation
 You can differentiate any SymPy expression using ``diff(func,
 var)``. Examples::
 
-    >>> diff(sin(x), x)
+    >>> sym.diff(sym.sin(x), x)
     cos(x)
-    >>> diff(sin(2*x), x)
+    >>> sym.diff(sym.sin(2*x), x)
     2*cos(2*x)
 
-    >>> diff(tan(x), x)
+    >>> sym.diff(sym.tan(x), x)
        2       
     tan (x) + 1
 
 You can check, that it is correct by::
 
-    >>> limit((tan(x+y) - tan(x))/y, y, 0)
+    >>> sym.limit((sym.tan(x+y) - sym.tan(x))/y, y, 0)
        2       
     tan (x) + 1
 
 Higher derivatives can be calculated using the ``diff(func, var, n)`` method::
 
-    >>> diff(sin(2*x), x, 1)
+    >>> sym.diff(sym.sin(2*x), x, 1)
     2*cos(2*x)
 
-    >>> diff(sin(2*x), x, 2)
+    >>> sym.diff(sym.sin(2*x), x, 2)
     -4*sin(2*x)
 
-    >>> diff(sin(2*x), x, 3)
+    >>> sym.diff(sym.sin(2*x), x, 3)
     -8*cos(2*x)
 
 
@@ -244,12 +244,12 @@ Series expansion
 SymPy also knows how to compute the Taylor series of an expression at
 a point. Use ``series(expr, var)``::
 
-    >>> series(cos(x), x)
+    >>> sym.series(sym.cos(x), x)
          2    4        
         x    x     / 6\
     1 - -- + -- + O\x /
         2    24        
-    >>> series(1/cos(x), x)
+    >>> sym.series(1/sym.cos(x), x)
          2      4        
         x    5*x     / 6\
     1 + -- + ---- + O\x /
@@ -268,24 +268,24 @@ Integration
 -----------
 
 SymPy has support for indefinite and definite integration of transcendental
-elementary and special functions via `integrate()` facility, which uses
-powerful extended Risch-Norman algorithm and some heuristics and pattern
+elementary and special functions via ``integrate()`` facility, which uses
+the powerful extended Risch-Norman algorithm and some heuristics and pattern
 matching. You can integrate elementary functions::
 
-    >>> integrate(6*x**5, x)
+    >>> sym.integrate(6*x**5, x)
      6
     x 
-    >>> integrate(sin(x), x)
+    >>> sym.integrate(sym.sin(x), x)
     -cos(x)
-    >>> integrate(log(x), x)
+    >>> sym.integrate(sym.log(x), x)
     x*log(x) - x
-    >>> integrate(2*x + sinh(x), x)
+    >>> sym.integrate(2*x + sym.sinh(x), x)
      2          
     x  + cosh(x)
 
 Also special functions are handled easily::
 
-    >>> integrate(exp(-x**2)*erf(x), x)
+    >>> sym.integrate(sym.exp(-x**2)*sym.erf(x), x)
       ____    2   
     \/ pi *erf (x)
     --------------
@@ -293,18 +293,18 @@ Also special functions are handled easily::
 
 It is possible to compute definite integral::
 
-    >>> integrate(x**3, (x, -1, 1))
+    >>> sym.integrate(x**3, (x, -1, 1))
     0
-    >>> integrate(sin(x), (x, 0, pi/2))
+    >>> sym.integrate(sym.sin(x), (x, 0, sym.pi/2))
     1
-    >>> integrate(cos(x), (x, -pi/2, pi/2))
+    >>> sym.integrate(sym.cos(x), (x, -sym.pi/2, sym.pi/2))
     2
 
 Also improper integrals are supported as well::
 
-    >>> integrate(exp(-x), (x, 0, oo))
+    >>> sym.integrate(sym.exp(-x), (x, 0, sym.oo))
     1
-    >>> integrate(exp(-x**2), (x, -oo, oo))
+    >>> sym.integrate(sym.exp(-x**2), (x, -sym.oo, sym.oo))
       ____
     \/ pi 
 
@@ -323,7 +323,7 @@ Equation solving
 SymPy is able to solve algebraic equations, in one and several
 variables::
 
-    In [7]: solve(x**4 - 1, x)
+    In [7]: sym.solve(x**4 - 1, x)
     Out[7]: [I, 1, -1, -I]
 
 As you can see it takes as first argument an expression that is
@@ -332,12 +332,12 @@ polynomial equations, and is also capable of solving multiple
 equations with respect to multiple variables giving a tuple as second
 argument::
 
-    In [8]: solve([x + 5*y - 2, -3*x + 6*y - 15], [x, y])
+    In [8]: sym.solve([x + 5*y - 2, -3*x + 6*y - 15], [x, y])
     Out[8]: {y: 1, x: -3}
 
-It also has (limited) support for trascendental equations::
+It also has (limited) support for transcendental equations::
 
-   In [9]: solve(exp(x) + 1, x)
+   In [9]: sym.solve(sym.exp(x) + 1, x)
    Out[9]: [pi*I]
 
 Another alternative in the case of polynomial equations is
@@ -346,10 +346,10 @@ terms, and is capable of computing the factorization over various
 domains::
 
    In [10]: f = x**4 - 3*x**2 + 1
-   In [11]: factor(f)
+   In [11]: sym.factor(f)
    Out[11]: (1 + x - x**2)*(1 - x - x**2)
 
-   In [12]: factor(f, modulus=5)
+   In [12]: sym.factor(f, modulus=5)
    Out[12]: (2 + x)**2*(2 - x)**2
 
 
@@ -358,14 +358,14 @@ SymPy is also able to solve boolean equations, that is, to decide if a
 certain boolean expression is satisfiable or not. For this, we use the
 function satisfiable::
 
-   In [13]: satisfiable(x & y)
+   In [13]: sym.satisfiable(x & y)
    Out[13]: {x: True, y: True}
 
-This tells us that (x & y) is True whenever x and y are both True. If
-an expression cannot be true, i.e. no values of its arguments can make
+This tells us that ``(x & y)`` is True whenever ``x`` and ``y`` are both True. 
+If an expression cannot be true, i.e. no values of its arguments can make
 the expression True, it will return False::
 
-   In [14]: satisfiable(x & ~x)
+   In [14]: sym.satisfiable(x & ~x)
    Out[14]: False
 
 
@@ -393,17 +393,15 @@ Matrices
 
 Matrices are created as instances from the Matrix class::
 
-    >>> from sympy import Matrix
-    >>> Matrix([[1,0], [0,1]])
+    >>> sym.Matrix([[1,0], [0,1]])
     [1  0]
     [    ]
     [0  1]
 
 unlike a NumPy array, you can also put Symbols in it::
 
-    >>> x = Symbol('x')
-    >>> y = Symbol('y')
-    >>> A = Matrix([[1,x], [y,1]])
+    >>> x, y = sym.symbols('x, y')
+    >>> A = sym.Matrix([[1,x], [y,1]])
     >>> A
     [1  x]
     [    ]
@@ -424,7 +422,7 @@ SymPy is capable of solving (some) Ordinary Differential.
 To solve differential equations, use dsolve. First, create
 an undefined function by passing cls=Function to the symbols function::
 
-    >>> f, g = symbols('f g', cls=Function)
+    >>> f, g = sym.symbols('f g', cls=sym.Function)
     
 f and g are now undefined functions. We can call f(x), and it will represent
 an unknown function::
@@ -439,16 +437,16 @@ an unknown function::
              2      
            dx       
 
-    >>> dsolve(f(x).diff(x, x) + f(x), f(x))
+    >>> sym.dsolve(f(x).diff(x, x) + f(x), f(x))
     f(x) = C1*sin(x) + C2*cos(x)
 
 
 Keyword arguments can be given to this function in order to help if
 find the best possible resolution system. For example, if you know
-that it is a separable equations, you can use keyword hint='separable'
+that it is a separable equations, you can use keyword ``hint='separable'``
 to force dsolve to resolve it as a separable equation::
 
-   >>> dsolve(sin(x)*cos(f(x)) + cos(x)*sin(f(x))*f(x).diff(x), f(x), hint='separable') # doctest: +NORMALIZE_WHITESPACE
+   >>> sym.dsolve(sym.sin(x)*sym.cos(f(x)) + sym.cos(x)*sym.sin(f(x))*f(x).diff(x), f(x), hint='separable') # doctest: +NORMALIZE_WHITESPACE
                  /     _________________\                  /     ________________
                  |    /      C1         |                  |    /      C1        
    [f(x) = - asin|   /  ----------- + 1 | + pi, f(x) = asin|   /  ----------- + 1
@@ -475,4 +473,4 @@ to force dsolve to resolve it as a separable equation::
     .. math::
         x \frac{d f(x)}{x} + f(x) - f(x)^2=0
 
-   2. Solve the same equation using hint='Bernoulli'. What do you observe ?
+   2. Solve the same equation using ``hint='Bernoulli'``. What do you observe ?

--- a/packages/sympy.rst
+++ b/packages/sympy.rst
@@ -1,10 +1,6 @@
 
 .. TODO: bench and fit in 1:30
 
-.. TODO: plotting <- broken in OSX
-   >>> import sympy
-   >>> sympy.init_printing(use_unicode=False, wrap_line=True, no_global=False)
-
 .. _sympy:
 
 ======================================
@@ -67,8 +63,7 @@ are treated as
 symbols and can be evaluated with arbitrary precision::
 
     >>> sym.pi**2
-      2
-    pi 
+    pi**2
 
     >>> sym.pi.evalf()
     3.14159265358979
@@ -109,8 +104,7 @@ Then you can manipulate them::
     2*x
 
     >>> (x + y)**2
-           2
-    (x + y) 
+    (x + y)**2
 
 Symbols can now be manipulated using some of python operators: ``+``, ``-`, 
 ``*``, ``**`` (arithmetic), &, `|`, ~ , >>, << (boolean).
@@ -118,9 +112,10 @@ Symbols can now be manipulated using some of python operators: ``+``, ``-`,
 
 .. topic:: **Printing**
 
-   Here we use the following setting for printing
+   Sympy allows for control of the display of the output. From here we use the 
+   following setting for printing
 
-    >>> sym.init_printing(use_unicode=False, wrap_line=True)
+   >>> sym.init_printing(use_unicode=False, wrap_line=True)
 
 
 

--- a/packages/sympy.rst
+++ b/packages/sympy.rst
@@ -44,11 +44,11 @@ Using SymPy as a calculator
 SymPy defines three numerical types: ``Real``, ``Rational`` and ``Integer``.
 
 The Rational class represents a rational number as a pair of two
-Integers: the numerator and the denominator, so ``Rational(1,2)``
-represents 1/2, ``Rational(5,2)`` 5/2 and so on::
+Integers: the numerator and the denominator, so ``Rational(1, 2)``
+represents 1/2, ``Rational(5, 2)`` 5/2 and so on::
 
     >>> import sympy as sym
-    >>> a = sym.Rational(1,2)
+    >>> a = sym.Rational(1, 2)
 
     >>> a
     1/2
@@ -103,7 +103,7 @@ Then you can manipulate them::
     >>> x + y + x - y
     2*x
 
-    >>> (x + y)**2
+    >>> (x + y) ** 2
     (x + y)**2
 
 Symbols can now be manipulated using some of python operators: ``+``, ``-`, 
@@ -131,10 +131,10 @@ Expand
 Use this to expand an algebraic expression. It will try to denest
 powers and multiplications::
 
-    >>> sym.expand((x + y)**3)
+    >>> sym.expand((x + y) ** 3)
      3      2          2    3
     x  + 3*x *y + 3*x*y  + y 
-    >>> 3*x*y**2 + 3*y*x**2 + x**3 + y**3
+    >>> 3 * x * y ** 2 + 3 * y * x ** 2 + x ** 3 + y ** 3
      3      2          2    3
     x  + 3*x *y + 3*x*y  + y 
 
@@ -143,12 +143,12 @@ Further options can be given in form on keywords::
 
     >>> sym.expand(x + y, complex=True)
     re(x) + re(y) + I*im(x) + I*im(y)
-    >>> sym.I*sym.im(x) + sym.I*sym.im(y) + sym.re(x) + sym.re(y)
+    >>> sym.I * sym.im(x) + sym.I * sym.im(y) + sym.re(x) + sym.re(y)
     re(x) + re(y) + I*im(x) + I*im(y)
 
     >>> sym.expand(sym.cos(x + y), trig=True)
     -sin(x)*sin(y) + cos(x)*cos(y)
-    >>> sym.cos(x)*sym.cos(y) - sym.sin(x)*sym.sin(y)
+    >>> sym.cos(x) * sym.cos(y) - sym.sin(x) * sym.sin(y)
     -sin(x)*sin(y) + cos(x)*cos(y)
 
 Simplify
@@ -157,7 +157,7 @@ Simplify
 Use simplify if you would like to transform an expression into a
 simpler form::
 
-    >>> sym.simplify((x + x*y) / x)
+    >>> sym.simplify((x + x * y) / x)
     y + 1
 
 
@@ -183,7 +183,7 @@ Limits are easy to use in SymPy, they follow the syntax ``limit(function,
 variable, point)``, so to compute the limit of :math:`f(x)` as 
 :math:`x \rightarrow 0`, you would issue ``limit(f, x, 0)``::
 
-   >>> sym.limit(sym.sin(x)/x, x, 0)
+   >>> sym.limit(sym.sin(x) / x, x, 0)
    1
 
 you can also calculate the limit at infinity::
@@ -191,10 +191,10 @@ you can also calculate the limit at infinity::
    >>> sym.limit(x, x, sym.oo)
    oo
 
-   >>> sym.limit(1/x, x, sym.oo)
+   >>> sym.limit(1 / x, x, sym.oo)
    0
 
-   >>> sym.limit(x**x, x, 0)
+   >>> sym.limit(x ** x, x, 0)
    1
 
 
@@ -208,7 +208,7 @@ var)``. Examples::
 
     >>> sym.diff(sym.sin(x), x)
     cos(x)
-    >>> sym.diff(sym.sin(2*x), x)
+    >>> sym.diff(sym.sin(2 * x), x)
     2*cos(2*x)
 
     >>> sym.diff(sym.tan(x), x)
@@ -217,19 +217,19 @@ var)``. Examples::
 
 You can check, that it is correct by::
 
-    >>> sym.limit((sym.tan(x+y) - sym.tan(x))/y, y, 0)
+    >>> sym.limit((sym.tan(x + y) - sym.tan(x)) / y, y, 0)
        2       
     tan (x) + 1
 
 Higher derivatives can be calculated using the ``diff(func, var, n)`` method::
 
-    >>> sym.diff(sym.sin(2*x), x, 1)
+    >>> sym.diff(sym.sin(2 * x), x, 1)
     2*cos(2*x)
 
-    >>> sym.diff(sym.sin(2*x), x, 2)
+    >>> sym.diff(sym.sin(2 * x), x, 2)
     -4*sin(2*x)
 
-    >>> sym.diff(sym.sin(2*x), x, 3)
+    >>> sym.diff(sym.sin(2 * x), x, 3)
     -8*cos(2*x)
 
 
@@ -267,20 +267,20 @@ elementary and special functions via ``integrate()`` facility, which uses
 the powerful extended Risch-Norman algorithm and some heuristics and pattern
 matching. You can integrate elementary functions::
 
-    >>> sym.integrate(6*x**5, x)
+    >>> sym.integrate(6 * x ** 5, x)
      6
     x 
     >>> sym.integrate(sym.sin(x), x)
     -cos(x)
     >>> sym.integrate(sym.log(x), x)
     x*log(x) - x
-    >>> sym.integrate(2*x + sym.sinh(x), x)
+    >>> sym.integrate(2 * x + sym.sinh(x), x)
      2          
     x  + cosh(x)
 
 Also special functions are handled easily::
 
-    >>> sym.integrate(sym.exp(-x**2)*sym.erf(x), x)
+    >>> sym.integrate(sym.exp(-x ** 2) * sym.erf(x), x)
       ____    2   
     \/ pi *erf (x)
     --------------
@@ -290,16 +290,16 @@ It is possible to compute definite integral::
 
     >>> sym.integrate(x**3, (x, -1, 1))
     0
-    >>> sym.integrate(sym.sin(x), (x, 0, sym.pi/2))
+    >>> sym.integrate(sym.sin(x), (x, 0, sym.pi / 2))
     1
-    >>> sym.integrate(sym.cos(x), (x, -sym.pi/2, sym.pi/2))
+    >>> sym.integrate(sym.cos(x), (x, -sym.pi / 2, sym.pi / 2))
     2
 
 Also improper integrals are supported as well::
 
     >>> sym.integrate(sym.exp(-x), (x, 0, sym.oo))
     1
-    >>> sym.integrate(sym.exp(-x**2), (x, -sym.oo, sym.oo))
+    >>> sym.integrate(sym.exp(-x ** 2), (x, -sym.oo, sym.oo))
       ____
     \/ pi 
 
@@ -327,7 +327,7 @@ polynomial equations, and is also capable of solving multiple
 equations with respect to multiple variables giving a tuple as second
 argument::
 
-    In [8]: sym.solve([x + 5*y - 2, -3*x + 6*y - 15], [x, y])
+    In [8]: sym.solve([x + 5 * y - 2, -3 * x + 6 * y - 15], [x, y])
     Out[8]: {y: 1, x: -3}
 
 It also has (limited) support for transcendental equations::
@@ -340,9 +340,9 @@ Another alternative in the case of polynomial equations is
 terms, and is capable of computing the factorization over various
 domains::
 
-   In [10]: f = x**4 - 3*x**2 + 1
+   In [10]: f = x ** 4 - 3 * x ** 2 + 1
    In [11]: sym.factor(f)
-   Out[11]: (1 + x - x**2)*(1 - x - x**2)
+   Out[11]: (1 + x - x ** 2) * (1 - x - x ** 2)
 
    In [12]: sym.factor(f, modulus=5)
    Out[12]: (2 + x)**2*(2 - x)**2
@@ -388,7 +388,7 @@ Matrices
 
 Matrices are created as instances from the Matrix class::
 
-    >>> sym.Matrix([[1,0], [0,1]])
+    >>> sym.Matrix([[1, 0], [0, 1]])
     [1  0]
     [    ]
     [0  1]
@@ -396,7 +396,7 @@ Matrices are created as instances from the Matrix class::
 unlike a NumPy array, you can also put Symbols in it::
 
     >>> x, y = sym.symbols('x, y')
-    >>> A = sym.Matrix([[1,x], [y,1]])
+    >>> A = sym.Matrix([[1, x], [y, 1]])
     >>> A
     [1  x]
     [    ]
@@ -441,7 +441,7 @@ find the best possible resolution system. For example, if you know
 that it is a separable equations, you can use keyword ``hint='separable'``
 to force dsolve to resolve it as a separable equation::
 
-   >>> sym.dsolve(sym.sin(x)*sym.cos(f(x)) + sym.cos(x)*sym.sin(f(x))*f(x).diff(x), f(x), hint='separable') # doctest: +NORMALIZE_WHITESPACE
+   >>> sym.dsolve(sym.sin(x) * sym.cos(f(x)) + sym.cos(x) * sym.sin(f(x)) * f(x).diff(x), f(x), hint='separable') # doctest: +NORMALIZE_WHITESPACE
                  /     _________________\                  /     ________________
                  |    /      C1         |                  |    /      C1        
    [f(x) = - asin|   /  ----------- + 1 | + pi, f(x) = asin|   /  ----------- + 1


### PR DESCRIPTION
Two things here (happy to revert to simplify the PR):

1. 917a602 implements the discussion at #297: changes `from sympy import *` to `import sympy as sym`.
2. fdfa8ca changes the `init_printing` call: it was called at the start (in a hidden `TODO`) and then called again to show the reader. However this would result in no change of behaviour. This didactically shows the effect of calling `init_printing`. 

 
