### PR TITLE
Move from sym.solve to sym.solveset.

### DIFF
--- a/packages/sympy.rst
+++ b/packages/sympy.rst
@@ -316,7 +316,7 @@ Equation solving
 ================
 
 SymPy is able to solve algebraic equations, in one and several
-variables::
+variables using :func:`~sympy.solveset`::
 
     >>> sym.solveset(x ** 4 - 1, x)
     {-1, 1, -I, I}
@@ -328,10 +328,10 @@ equations::
    >>> sym.solveset(sym.exp(x) + 1, x)
    {I*(2*n*pi + pi) | n in Integers()}
 
-It is able to solve a large part of
+Sympy is able to solve a large part of
 polynomial equations, and is also capable of solving multiple
 equations with respect to multiple variables giving a tuple as second
-argument. To do this you use the ``solve`` command::
+argument. To do this you use the :func:`~sympy.solve` command::
 
     >>> solution = sym.solve((x + 5 * y - 2, -3 * x + 6 * y - 15), (x, y))
     >>> solution[x], solution[y]

--- a/packages/sympy.rst
+++ b/packages/sympy.rst
@@ -82,11 +82,11 @@ There is also a class representing mathematical infinity, called
     oo
 
 
-Exercises
----------
+.. topic:: **Exercises**
+   :class: green
 
-1. Calculate :math:`\sqrt{2}` with 100 decimals.
-2. Calculate :math:`1/2 + 1/3` in rational arithmetic.
+   1. Calculate :math:`\sqrt{2}` with 100 decimals.
+   2. Calculate :math:`1/2 + 1/3` in rational arithmetic.
 
 
 Symbols
@@ -113,7 +113,7 @@ Symbols can now be manipulated using some of python operators: ``+``, ``-`,
 .. topic:: **Printing**
 
    Sympy allows for control of the display of the output. From here we use the 
-   following setting for printing
+   following setting for printing::
 
    >>> sym.init_printing(use_unicode=False, wrap_line=True)
 
@@ -307,11 +307,6 @@ Also improper integrals are supported as well::
 .. index:: equations; algebraic, solve
 
 
-Exercises
----------
-
-  
-
 Equation solving
 ================
 
@@ -328,14 +323,16 @@ equations::
    >>> sym.solveset(sym.exp(x) + 1, x)
    {I*(2*n*pi + pi) | n in Integers()}
 
-Sympy is able to solve a large part of
-polynomial equations, and is also capable of solving multiple
-equations with respect to multiple variables giving a tuple as second
-argument. To do this you use the :func:`~sympy.solve` command::
+.. topic:: **Systems of linear equations**
 
-    >>> solution = sym.solve((x + 5 * y - 2, -3 * x + 6 * y - 15), (x, y))
-    >>> solution[x], solution[y]
-    (-3, 1)
+   Sympy is able to solve a large part of
+   polynomial equations, and is also capable of solving multiple
+   equations with respect to multiple variables giving a tuple as second
+   argument. To do this you use the :func:`~sympy.solve` command::
+
+   >>> solution = sym.solve((x + 5 * y - 2, -3 * x + 6 * y - 15), (x, y))
+   >>> solution[x], solution[y]
+   (-3, 1)
 
 Another alternative in the case of polynomial equations is
 `factor`. `factor` returns the polynomial factorized into irreducible
@@ -350,8 +347,6 @@ domains::
    >>> sym.factor(f, modulus=5)
           2        2
    (x - 2) *(x + 2) 
-
-
 
 SymPy is also able to solve boolean equations, that is, to decide if a
 certain boolean expression is satisfiable or not. For this, we use the
@@ -368,18 +363,12 @@ the expression True, it will return False::
    False
 
 
-Exercises
----------
 
-1. Solve the system of equations :math:`x + y = 2`, :math:`2\cdot x + y = 0`
-2. Are there boolean values ``x``, ``y`` that make ``(~x | y) & (~y | x)`` true?
+.. topic:: **Exercises**
+   :class: green
 
-
-.. Polynomial computations
-.. =======================
-
-.. SymPy has a rich module of efficient polynomial routines. Some of the
-.. most commonly used methods are factor, gcd
+   1. Solve the system of equations :math:`x + y = 2`, :math:`2\cdot x + y = 0`
+   2. Are there boolean values ``x``, ``y`` that make ``(~x | y) & (~y | x)`` true?
 
 
 Linear Algebra

--- a/packages/sympy.rst
+++ b/packages/sympy.rst
@@ -318,34 +318,38 @@ Equation solving
 SymPy is able to solve algebraic equations, in one and several
 variables::
 
-    In [7]: sym.solve(x**4 - 1, x)
-    Out[7]: [I, 1, -1, -I]
+    >>> sym.solveset(x ** 4 - 1, x)
+    {-1, 1, -I, I}
 
 As you can see it takes as first argument an expression that is
-supposed to be equaled to 0. It is able to solve a large part of
+supposed to be equaled to 0. It also has (limited) support for transcendental 
+equations::
+
+   >>> sym.solveset(sym.exp(x) + 1, x)
+   {I*(2*n*pi + pi) | n in Integers()}
+
+It is able to solve a large part of
 polynomial equations, and is also capable of solving multiple
 equations with respect to multiple variables giving a tuple as second
-argument::
+argument. To do this you use the ``solve`` command::
 
-    In [8]: sym.solve([x + 5 * y - 2, -3 * x + 6 * y - 15], [x, y])
-    Out[8]: {y: 1, x: -3}
-
-It also has (limited) support for transcendental equations::
-
-   In [9]: sym.solve(sym.exp(x) + 1, x)
-   Out[9]: [pi*I]
+    >>> solution = sym.solve((x + 5 * y - 2, -3 * x + 6 * y - 15), (x, y))
+    >>> solution[x], solution[y]
+    (-3, 1)
 
 Another alternative in the case of polynomial equations is
 `factor`. `factor` returns the polynomial factorized into irreducible
 terms, and is capable of computing the factorization over various
 domains::
 
-   In [10]: f = x ** 4 - 3 * x ** 2 + 1
-   In [11]: sym.factor(f)
-   Out[11]: (1 + x - x ** 2) * (1 - x - x ** 2)
+   >>> f = x ** 4 - 3 * x ** 2 + 1
+   >>> sym.factor(f)
+   / 2        \ / 2        \
+   \x  - x - 1/*\x  + x - 1/
 
-   In [12]: sym.factor(f, modulus=5)
-   Out[12]: (2 + x)**2*(2 - x)**2
+   >>> sym.factor(f, modulus=5)
+          2        2
+   (x - 2) *(x + 2) 
 
 
 
@@ -353,15 +357,15 @@ SymPy is also able to solve boolean equations, that is, to decide if a
 certain boolean expression is satisfiable or not. For this, we use the
 function satisfiable::
 
-   In [13]: sym.satisfiable(x & y)
-   Out[13]: {x: True, y: True}
+   >>> sym.satisfiable(x & y)
+   {x: True, y: True}
 
 This tells us that ``(x & y)`` is True whenever ``x`` and ``y`` are both True. 
 If an expression cannot be true, i.e. no values of its arguments can make
 the expression True, it will return False::
 
-   In [14]: sym.satisfiable(x & ~x)
-   Out[14]: False
+   >>> sym.satisfiable(x & ~x)
+   False
 
 
 Exercises


### PR DESCRIPTION
Closes #308.

This fixes a number of outputs that were not being doctested (the
Jupyter `In` `Out` prompt was being used which is not recognised by the
python doctest module).

Note that I did not change `sym.solve` for the case of the system of
equations (the alternatives are not yet implemented in solveset and I feel
make things more complicated than they need to be). FWIW in my own
teaching I do not consider systems of linear equations using any of the
solvers and instead show students how to use Numpy (or indeed Sympy) to
do this using matrices.