### PR TITLE
include latex_preamble in latex_elements

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -361,6 +361,7 @@ latex_preamble = r"""
 """
 
 latex_elements = {
+    'preamble': latex_preamble,
     'fontpkg': '\\usepackage{lmodern}',
     'fncychap': r'''%
     \usepackage[Sonny]{fncychap}%


### PR DESCRIPTION
According to sphinx's documentation, a stand-alone latex_preamble variable is
deprecated since version 0.5 http://www.sphinx-doc.org/en/1.5.6/config.html