### PR TITLE
make prompt '>>>' and output unselectable

### DIFF
--- a/themes/scipy_lectures/static/nature.css_t
+++ b/themes/scipy_lectures/static/nature.css_t
@@ -1037,3 +1037,9 @@ div.sphx-glr-script-out div.highlight pre div.newline {
 div.sphx-glr-script-out div.highlight pre {
     text-indent: 0em;
 }
+.gp, .go {
+    -webkit-user-select: none; /* Chrome, Opera, Safari */
+    -moz-user-select: none; /* Firefox 2+ */
+    -ms-user-select: none; /* IE 10+ */
+    user-select: none; /* Standard syntax */
+} 


### PR DESCRIPTION
This is done by adding a custom css file that acts on the ".gp" and ".go" classes.