### PR TITLE
Fix c module python 2 3

### DIFF
--- a/advanced/interfacing_with_c/interfacing_with_c.rst
+++ b/advanced/interfacing_with_c/interfacing_with_c.rst
@@ -162,6 +162,12 @@ This can be compiled:
 
 The file ``cos_module.so`` contains the compiled extension, which we can now load in the IPython interpreter:
 
+.. note::
+
+   In Python 3, the filename for compiled modules includes metadata on the Python
+   interpreter (see `PEP 3149 <https://www.python.org/dev/peps/pep-3149/>`_) and is thus
+   longer. The import statement is not affected by this.
+
 .. sourcecode:: ipython
 
     In [1]: import cos_module

--- a/advanced/interfacing_with_c/python_c_api/cos_module.c
+++ b/advanced/interfacing_with_c/python_c_api/cos_module.c
@@ -31,9 +31,27 @@ static PyMethodDef CosMethods[] =
 };
 
 /* module initialization */
+/* Python version 3*/
+static struct PyModuleDef cModPyDem =
+{
+    PyModuleDef_HEAD_INIT,
+    "cos_module", "Some documentation",
+    -1,
+    CosMethods
+};
 PyMODINIT_FUNC
+PyInit_cos_module(void)
+{
+    return PyModule_Create(&cModPyDem);
+}
 
+
+/* module initialization */
+/* Python version 2 */
+/*
+PyMODINIT_FUNC
 initcos_module(void)
 {
      (void) Py_InitModule("cos_module", CosMethods);
 }
+*/

--- a/advanced/interfacing_with_c/python_c_api/cos_module.c
+++ b/advanced/interfacing_with_c/python_c_api/cos_module.c
@@ -30,6 +30,7 @@ static PyMethodDef CosMethods[] =
      {NULL, NULL, 0, NULL}
 };
 
+#if PY_MAJOR_VERSION >= 3
 /* module initialization */
 /* Python version 3*/
 static struct PyModuleDef cModPyDem =
@@ -39,19 +40,21 @@ static struct PyModuleDef cModPyDem =
     -1,
     CosMethods
 };
+
 PyMODINIT_FUNC
 PyInit_cos_module(void)
 {
     return PyModule_Create(&cModPyDem);
 }
 
+#else
 
 /* module initialization */
 /* Python version 2 */
-/*
 PyMODINIT_FUNC
 initcos_module(void)
 {
-     (void) Py_InitModule("cos_module", CosMethods);
+    (void) Py_InitModule("cos_module", CosMethods);
 }
-*/
+
+#endif


### PR DESCRIPTION
Make the c module in `advanced/interfacing_with_c/python_c_api/cos_module.c` 2/3 compatible.

Add a note about the filenames of Python 3 extensions in the corresponding text.

Finishes #225 that was only Python 3 compatible.