### PR TITLE
Building instructions for Debian/Ubuntu added

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,3 +65,60 @@ Requirements
         pip install scikit-learn
         pip install scikit-image
 
+.. topic:: Building on Debian/Ubuntu
+
+    The environment needed to create an HTML version of the SciPy lecture notes
+    can be based on miniconda. We first download the latest version of miniconda
+    and rename it to `miniconda.sh` for simplicity::
+
+       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+
+    To ensure that the file has been downloaded correctly, one can compare the
+    MD5 sum obtained by means of::
+
+        md5sum miniconda.sh
+
+    with the value listed on https://repo.continuum.io/miniconda/ . Miniconda can
+    now be installed::
+
+        bash miniconda.sh
+        
+    Review the license agreement and choose a target directory (here we assume it
+    to be `$HOME/miniconda2`). Unless you intend to work more extensively with
+    miniconda, you do not want to modify `.bashrc`. In this case, you need::
+
+        export PATH=$HOME/miniconda2/bin:$PATH
+
+    to find the correct binaries. Note that the path depends on the target directory
+    chosen above.
+
+    Now, we use `environment.yml` from the main directory of the scipy-lecture-notes
+    repository to install the required dependencies. Note that `environment.yml` yields
+    an environment named `testenv`. If you prefer a more telling name, make a copy of
+    `environment.yml`, replace `testenv` in line 4 by a more appropriate name and use
+    this name in the following instead of `testenv`. The conda environment is created
+    by::
+
+        conda env create -f environment.yml
+
+    Now, the environment can be activated::
+
+        source activate testenv
+
+    and deactivated::
+
+        source deactivate
+
+    With an activated environment, you are now able to produce the HTML version of the
+    SciPy lecture notes by running::
+
+        make html
+
+    in the main directory of the repository.
+
+    A PDF version can be obtained by means of::
+
+        make pdf
+
+    Required system packages are `texlive`, `texlive-latex-extra`, `texlive-fonts-extra`,
+    and `latexmk`.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -110,15 +110,5 @@ Requirements
         source deactivate
 
     With an activated environment, you are now able to produce the HTML version of the
-    SciPy lecture notes by running::
-
-        make html
-
-    in the main directory of the repository.
-
-    A PDF version can be obtained by means of::
-
-        make pdf
-
-    Required system packages are ``texlive``, ``texlive-latex-extra``, ``texlive-fonts-extra``,
-    and ``latexmk``.
+    SciPy as explained above. Generating a PDF version requires the system packages
+    ``texlive``, ``texlive-latex-extra``, ``texlive-fonts-extra``, and ``latexmk``.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,7 +54,7 @@ Requirements
 |
 |
 
-.. topic:: Building on Fedora
+.. topic:: **Building on Fedora**
 
     As root::
 
@@ -69,7 +69,7 @@ Requirements
 
     The environment needed to create an HTML version of the SciPy lecture notes
     can be based on miniconda. We first download the latest version of miniconda
-    and rename it to `miniconda.sh` for simplicity::
+    and rename it to ``miniconda.sh`` for simplicity::
 
        wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
 
@@ -84,19 +84,19 @@ Requirements
         bash miniconda.sh
         
     Review the license agreement and choose a target directory (here we assume it
-    to be `$HOME/miniconda2`). Unless you intend to work more extensively with
-    miniconda, you do not want to modify `.bashrc`. In this case, you need::
+    to be ``$HOME/miniconda2``). Unless you intend to work more extensively with
+    miniconda, you do not want to modify ``.bashrc``. In this case, you need::
 
         export PATH=$HOME/miniconda2/bin:$PATH
 
     to find the correct binaries. Note that the path depends on the target directory
     chosen above.
 
-    Now, we use `environment.yml` from the main directory of the scipy-lecture-notes
-    repository to install the required dependencies. Note that `environment.yml` yields
-    an environment named `testenv`. If you prefer a more telling name, make a copy of
-    `environment.yml`, replace `testenv` in line 4 by a more appropriate name and use
-    this name in the following instead of `testenv`. The conda environment is created
+    Now, we use ``environment.yml`` from the main directory of the ``scipy-lecture-notes``
+    repository to install the required dependencies. Note that ``environment.yml`` yields
+    an environment named ``testenv``. If you prefer a more telling name, make a copy of
+    ``environment.yml``, replace ``testenv`` in line 4 by a more appropriate name and use
+    this name in the following instead of ``testenv``. The conda environment is created
     by::
 
         conda env create -f environment.yml
@@ -120,5 +120,5 @@ Requirements
 
         make pdf
 
-    Required system packages are `texlive`, `texlive-latex-extra`, `texlive-fonts-extra`,
-    and `latexmk`.
+    Required system packages are ``texlive``, ``texlive-latex-extra``, ``texlive-fonts-extra``,
+    and ``latexmk``.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,7 +54,7 @@ Requirements
 |
 |
 
-.. topic:: **Building on Fedora**
+.. topic:: Building on Fedora
 
     As root::
 
@@ -65,7 +65,7 @@ Requirements
         pip install scikit-learn
         pip install scikit-image
 
-.. topic:: Building on Debian/Ubuntu
+.. topic:: **Building on Debian/Ubuntu**
 
     The environment needed to create an HTML version of the SciPy lecture notes
     can be based on miniconda. We first download the latest version of miniconda

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,7 +67,7 @@ Requirements
 
 .. topic:: **Building on Debian/Ubuntu**
 
-    The environment needed to create an HTML version of the SciPy lecture notes
+    The environment needed to create an html version of the SciPy lecture notes
     can be based on miniconda. We first download the latest version of miniconda
     and rename it to ``miniconda.sh`` for simplicity::
 
@@ -109,6 +109,6 @@ Requirements
 
         source deactivate
 
-    With an activated environment, you are now able to produce the HTML version of the
-    SciPy as explained above. Generating a PDF version requires the system packages
+    With an activated environment, you are now able to produce the html version of the
+    SciPy as explained above. Generating a pdf version requires the system packages
     ``texlive``, ``texlive-latex-extra``, ``texlive-fonts-extra``, and ``latexmk``.


### PR DESCRIPTION
This PR adds a rather explicit description of how to set up a miniconda environment to produce the lecture notes in html and pdf format. In this way, at least users on Linux and MacOS should be able to use the same environment as the one used in the tests. I kept the requirements and Fedora sections even though they seem outdated and might not be needed anymore.