### PR TITLE
fix the sphinx settings for papersize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,8 @@
 PYTHON        = python
 SPHINXOPTS    =
 SPHINXBUILD   = $(PYTHON) -m sphinx
-PAPER         = a4
 
-# Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d build/doctrees $(SPHINXOPTS) .
 
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck zip

--- a/conf.py
+++ b/conf.py
@@ -346,6 +346,7 @@ preamble = r"""
 """
 
 latex_elements = {
+    'papersize': 'a4paper',
     'preamble': preamble,
     'fontpkg': '\\usepackage{lmodern}',
     'fncychap': r'''%


### PR DESCRIPTION
The previous setting was wrong and sphinx used the default setting.

The setting must be `a4paper` and not `a4`. I placed it in `conf.py` instead of command-line arguments in the Makefile. The cover is a4 anyway and won't fit in letter format.