### PR TITLE
Fix the interpolation code to match the images

### DIFF
--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -154,10 +154,10 @@ Draw contour lines::
 
     [:ref:`Python source code <example_plot_display_face.py>`]
 
-For fine inspection of intensity variations, use
+For smooth intensity variations, use ``interpolation='bilinear'``. For fine inspection of intensity variations, use
 ``interpolation='nearest'``::
 
-    >>> plt.imshow(f[320:340, 510:530], cmap=plt.cm.gray)        # doctest: +ELLIPSIS
+    >>> plt.imshow(f[320:340, 510:530], cmap=plt.cm.gray, interpolation='bilinear')        # doctest: +ELLIPSIS
     <matplotlib.image.AxesImage object at 0x...>
     >>> plt.imshow(f[320:340, 510:530], cmap=plt.cm.gray, interpolation='nearest')        # doctest: +ELLIPSIS
     <matplotlib.image.AxesImage object at 0x...>
@@ -169,6 +169,12 @@ For fine inspection of intensity variations, use
 .. only:: html
 
     [:ref:`Python source code <example_plot_interpolation_face.py>`]
+
+
+.. seealso::
+
+    More interpolation methods are in  `Matplotlib's examples <https://matplotlib.org/examples/images_contours_and_fields/interpolation_methods.html>`_.
+
 
 
 .. seealso:: 3-D visualization: Mayavi


### PR DESCRIPTION
The code examples for interpolating the face image show no option being passed to `interpolation`, then `nearest` being passed. 
However the images first show a smooth interpolation, followed by the rough `nearest`. I'm not sure if the default used to be bilinear, but now when you run the examples, the default of `interpolation=none` is the same as `nearest`, so you get two of the same result if you copy paste the code.

I also added the link to the matplotlib interpolation example because it is a quick illustrator to the types you can choose from