### PR TITLE
For travis builds, test on TRAVIS environment var

### DIFF
--- a/build_tools/install.sh
+++ b/build_tools/install.sh
@@ -27,7 +27,7 @@ create_new_venv() {
 
 create_new_conda_env() {
     # Skip Travis related code on circle ci.
-    if [ -z $CIRCLECI ]; then
+    if [  "$TRAVIS" == true ]; then
         # Deactivate the travis-provided virtual environment and setup a
         # conda-based environment instead
         deactivate


### PR DESCRIPTION
Purpuse of this section is to deactivate a default virtual environment provided
by travisi

Rather than testing on the absence of a CIRLCE_CI variable, test on TRAVIS
instead which is given for all builds with default value "true"