### PR TITLE
CLN: replace all usage of pylab with matplotlib.pyplot

### DIFF
--- a/advanced/debugging/wiener_filtering.py
+++ b/advanced/debugging/wiener_filtering.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import scipy as sp
-import pylab as pl
+import matplotlib.pyplot as plt
 from scipy import signal
 
 
@@ -51,11 +51,11 @@ np.random.seed(7)
 face = sp.misc.face(gray=True)
 noisy_face = face + 20*np.random.randint(3, size=face.shape) - 30
 
-pl.matshow(face[cut], cmap=pl.cm.gray)
-pl.matshow(noisy_face[cut], cmap=pl.cm.gray)
+plt.matshow(face[cut], cmap=plt.cm.gray)
+plt.matshow(noisy_face[cut], cmap=plt.cm.gray)
 
 denoised_face = iterated_wiener(noisy_face)
-pl.matshow(denoised_face[cut], cmap=pl.cm.gray)
+plt.matshow(denoised_face[cut], cmap=plt.cm.gray)
 
-pl.show()
+plt.show()
 

--- a/advanced/interfacing_with_c/numpy_c_api/test_cos_module_np.py
+++ b/advanced/interfacing_with_c/numpy_c_api/test_cos_module_np.py
@@ -1,8 +1,8 @@
 import cos_module_np
 import numpy as np
-import pylab
+import matplotlib.pyplot as plt
 
 x = np.arange(0, 2 * np.pi, 0.1)
 y = cos_module_np.cos_func_np(x)
-pylab.plot(x, y)
-pylab.show()
+plt.plot(x, y)
+plt.show()

--- a/advanced/interfacing_with_c/numpy_shared/test_cos_doubles.py
+++ b/advanced/interfacing_with_c/numpy_shared/test_cos_doubles.py
@@ -1,10 +1,10 @@
 import numpy as np
-import pylab
+import matplotlib.pyplot as plt
 import cos_doubles
 
 x = np.arange(0, 2 * np.pi, 0.1)
 y = np.empty_like(x)
 
 cos_doubles.cos_doubles_func(x, y)
-pylab.plot(x, y)
-pylab.show()
+plt.plot(x, y)
+plt.show()

--- a/advanced/mathematical_optimization/examples/plot_1d_optim.py
+++ b/advanced/mathematical_optimization/examples/plot_1d_optim.py
@@ -6,7 +6,7 @@ Illustration of 1D optimization: Brent's method
 """
 
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 from scipy import optimize
 
 x = np.linspace(-1, 3, 100)
@@ -16,11 +16,11 @@ def f(x):
     return (x - x_0)**2 + epsilon*np.exp(-5*(x - .5 - x_0)**2)
 
 for epsilon in (0, 1):
-    pl.figure(figsize=(3, 2.5))
-    pl.axes([0, 0, 1, 1])
+    plt.figure(figsize=(3, 2.5))
+    plt.axes([0, 0, 1, 1])
 
     # A convex function
-    pl.plot(x, f(x), linewidth=2)
+    plt.plot(x, f(x), linewidth=2)
 
     # Apply brent method. To have access to the iteration, do this in an
     # artificial way: allow the algorithm to iter only once
@@ -37,21 +37,21 @@ for epsilon in (0, 1):
         all_x.append(this_x)
         all_y.append(f(this_x))
         if iter < 6:
-            pl.text(this_x - .05*np.sign(this_x) - .05,
+            plt.text(this_x - .05*np.sign(this_x) - .05,
                     f(this_x) + 1.2*(.3 - iter % 2), iter + 1,
                     size=12)
 
-    pl.plot(all_x[:10], all_y[:10], 'k+', markersize=12, markeredgewidth=2)
+    plt.plot(all_x[:10], all_y[:10], 'k+', markersize=12, markeredgewidth=2)
 
-    pl.plot(all_x[-1], all_y[-1], 'rx', markersize=12)
-    pl.axis('off')
-    pl.ylim(ymin=-1, ymax=8)
+    plt.plot(all_x[-1], all_y[-1], 'rx', markersize=12)
+    plt.axis('off')
+    plt.ylim(ymin=-1, ymax=8)
 
-    pl.figure(figsize=(4, 3))
-    pl.semilogy(np.abs(all_y - all_y[-1]), linewidth=2)
-    pl.ylabel('Error on f(x)')
-    pl.xlabel('Iteration')
-    pl.tight_layout()
+    plt.figure(figsize=(4, 3))
+    plt.semilogy(np.abs(all_y - all_y[-1]), linewidth=2)
+    plt.ylabel('Error on f(x)')
+    plt.xlabel('Iteration')
+    plt.tight_layout()
 
-pl.show()
+plt.show()
 

--- a/advanced/mathematical_optimization/examples/plot_compare_optimizers.py
+++ b/advanced/mathematical_optimization/examples/plot_compare_optimizers.py
@@ -10,7 +10,7 @@ import pickle
 import sys
 
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 
 results = pickle.load(open(
     'helper/compare_optimizers_py%s.pkl' % sys.version_info[0],
@@ -20,10 +20,10 @@ n_dims = len(results)
 
 symbols = 'o>*Ds'
 
-pl.figure(1, figsize=(10, 4))
-pl.clf()
+plt.figure(1, figsize=(10, 4))
+plt.clf()
 
-colors = pl.cm.Spectral(np.linspace(0, 1, n_dims))[:, :3]
+colors = plt.cm.Spectral(np.linspace(0, 1, n_dims))[:, :3]
 
 method_names = list(list(results.values())[0]['Rosenbrock  '].keys())
 method_names.sort(key=lambda x: x[::-1], reverse=True)
@@ -35,35 +35,35 @@ for n_dim_index, ((n_dim, n_dim_bench), color) in enumerate(
         for method_index, method_name, in enumerate(method_names):
             this_bench = cost_bench[method_name]
             bench = np.mean(this_bench)
-            pl.semilogy([method_index + .1*n_dim_index, ], [bench, ],
+            plt.semilogy([method_index + .1*n_dim_index, ], [bench, ],
                     marker=symbol, color=color)
 
 # Create a legend for the problem type
 for cost_name, symbol in zip(sorted(n_dim_bench.keys()),
             symbols):
-    pl.semilogy([-10, ], [0, ], symbol, color='.5',
+    plt.semilogy([-10, ], [0, ], symbol, color='.5',
             label=cost_name)
 
-pl.xticks(np.arange(n_methods), method_names, size=11)
-pl.xlim(-.2, n_methods - .5)
-pl.legend(loc='best', numpoints=1, handletextpad=0, prop=dict(size=12),
+plt.xticks(np.arange(n_methods), method_names, size=11)
+plt.xlim(-.2, n_methods - .5)
+plt.legend(loc='best', numpoints=1, handletextpad=0, prop=dict(size=12),
           frameon=False)
-pl.ylabel('# function calls (a.u.)')
+plt.ylabel('# function calls (a.u.)')
 
 # Create a second legend for the problem dimensionality
-pl.twinx()
+plt.twinx()
 
 for n_dim, color in zip(sorted(results.keys()), colors):
-    pl.plot([-10, ], [0, ], 'o', color=color,
+    plt.plot([-10, ], [0, ], 'o', color=color,
             label='# dim: %i' % n_dim)
-pl.legend(loc=(.47, .07), numpoints=1, handletextpad=0, prop=dict(size=12),
+plt.legend(loc=(.47, .07), numpoints=1, handletextpad=0, prop=dict(size=12),
           frameon=False, ncol=2)
-pl.xlim(-.2, n_methods - .5)
+plt.xlim(-.2, n_methods - .5)
 
-pl.xticks(np.arange(n_methods), method_names)
-pl.yticks(())
+plt.xticks(np.arange(n_methods), method_names)
+plt.yticks(())
 
-pl.tight_layout()
-pl.show()
+plt.tight_layout()
+plt.show()
 
 

--- a/advanced/mathematical_optimization/examples/plot_constraints.py
+++ b/advanced/mathematical_optimization/examples/plot_constraints.py
@@ -5,7 +5,7 @@ Constraint optimization: visualizing the geometry
 A small figure explaining optimization with constraints
 """
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 from scipy import optimize
 
 x, y = np.mgrid[-2.9:5.8:.05, -2.5:5:.05]
@@ -15,30 +15,30 @@ y = y.T
 for i in (1, 2):
     # Create 2 figure: only the second one will have the optimization
     # path
-    pl.figure(i, figsize=(3, 2.5))
-    pl.clf()
-    pl.axes([0, 0, 1, 1])
+    plt.figure(i, figsize=(3, 2.5))
+    plt.clf()
+    plt.axes([0, 0, 1, 1])
 
-    contours = pl.contour(np.sqrt((x - 3)**2 + (y - 2)**2),
+    contours = plt.contour(np.sqrt((x - 3)**2 + (y - 2)**2),
                         extent=[-3, 6, -2.5, 5],
-                        cmap=pl.cm.gnuplot)
-    pl.clabel(contours,
+                        cmap=plt.cm.gnuplot)
+    plt.clabel(contours,
             inline=1,
             fmt='%1.1f',
             fontsize=14)
-    pl.plot([-1.5, -1.5,  1.5,  1.5, -1.5],
+    plt.plot([-1.5, -1.5,  1.5,  1.5, -1.5],
             [-1.5,  1.5,  1.5, -1.5, -1.5], 'k', linewidth=2)
-    pl.fill_between([ -1.5,  1.5],
+    plt.fill_between([ -1.5,  1.5],
                     [ -1.5, -1.5],
                     [  1.5,  1.5],
                     color='.8')
-    pl.axvline(0, color='k')
-    pl.axhline(0, color='k')
+    plt.axvline(0, color='k')
+    plt.axhline(0, color='k')
 
-    pl.text(-.9, 4.4, '$x_2$', size=20)
-    pl.text(5.6, -.6, '$x_1$', size=20)
-    pl.axis('equal')
-    pl.axis('off')
+    plt.text(-.9, 4.4, '$x_2$', size=20)
+    plt.text(5.6, -.6, '$x_1$', size=20)
+    plt.axis('equal')
+    plt.axis('off')
 
 # And now plot the optimization path
 accumulator = list()
@@ -59,6 +59,6 @@ optimize.minimize(f, np.array([0, 0]), method="L-BFGS-B",
                      bounds=((-1.5, 1.5), (-1.5, 1.5)))
 
 accumulated = np.array(accumulator)
-pl.plot(accumulated[:, 0], accumulated[:, 1])
+plt.plot(accumulated[:, 0], accumulated[:, 1])
 
-pl.show()
+plt.show()

--- a/advanced/mathematical_optimization/examples/plot_convex.py
+++ b/advanced/mathematical_optimization/examples/plot_convex.py
@@ -6,41 +6,41 @@ A figure showing the definition of a convex function
 """
 
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 
 x = np.linspace(-1, 2)
 
-pl.figure(1, figsize=(3, 2.5))
-pl.clf()
+plt.figure(1, figsize=(3, 2.5))
+plt.clf()
 
 # A convex function
-pl.plot(x, x**2, linewidth=2)
-pl.text(-.7, -.6**2, '$f$', size=20)
+plt.plot(x, x**2, linewidth=2)
+plt.text(-.7, -.6**2, '$f$', size=20)
 
 # The tangent in one point
-pl.plot(x, 2*x - 1)
-pl.plot(1, 1, 'k+')
-pl.text(.3, -.75, "Tangent to $f$", size=15)
-pl.text(1, 1 - .5, 'C', size=15)
+plt.plot(x, 2*x - 1)
+plt.plot(1, 1, 'k+')
+plt.text(.3, -.75, "Tangent to $f$", size=15)
+plt.text(1, 1 - .5, 'C', size=15)
 
 # Convexity as barycenter
-pl.plot([.35, 1.85], [.35**2, 1.85**2])
-pl.plot([.35, 1.85], [.35**2, 1.85**2], 'k+')
-pl.text(.35 - .2, .35**2 + .1, 'A', size=15)
-pl.text(1.85 - .2, 1.85**2, 'B', size=15)
+plt.plot([.35, 1.85], [.35**2, 1.85**2])
+plt.plot([.35, 1.85], [.35**2, 1.85**2], 'k+')
+plt.text(.35 - .2, .35**2 + .1, 'A', size=15)
+plt.text(1.85 - .2, 1.85**2, 'B', size=15)
 
-pl.ylim(ymin=-1)
-pl.axis('off')
-pl.tight_layout()
+plt.ylim(ymin=-1)
+plt.axis('off')
+plt.tight_layout()
 
 # Convexity as barycenter
-pl.figure(2, figsize=(3, 2.5))
-pl.clf()
-pl.plot(x, x**2 + np.exp(-5*(x - .5)**2), linewidth=2)
-pl.text(-.7, -.6**2, '$f$', size=20)
+plt.figure(2, figsize=(3, 2.5))
+plt.clf()
+plt.plot(x, x**2 + np.exp(-5*(x - .5)**2), linewidth=2)
+plt.text(-.7, -.6**2, '$f$', size=20)
 
-pl.ylim(ymin=-1)
-pl.axis('off')
-pl.tight_layout()
-pl.show()
+plt.ylim(ymin=-1)
+plt.axis('off')
+plt.tight_layout()
+plt.show()
 

--- a/advanced/mathematical_optimization/examples/plot_curve_fitting.py
+++ b/advanced/mathematical_optimization/examples/plot_curve_fitting.py
@@ -7,7 +7,7 @@ A curve fitting example
 
 import numpy as np
 from scipy import optimize
-import pylab as pl
+import matplotlib.pyplot as plt
 
 np.random.seed(0)
 
@@ -26,9 +26,9 @@ params, params_cov = optimize.curve_fit(f, x, y)
 # plot the data and the fitted curve
 t = np.linspace(0, 3, 1000)
 
-pl.figure(1)
-pl.clf()
-pl.plot(x, y, 'bx')
-pl.plot(t, f(t, *params), 'r-')
-pl.show()
+plt.figure(1)
+plt.clf()
+plt.plot(x, y, 'bx')
+plt.plot(t, f(t, *params), 'r-')
+plt.show()
 

--- a/advanced/mathematical_optimization/examples/plot_exercise_flat_minimum.py
+++ b/advanced/mathematical_optimization/examples/plot_exercise_flat_minimum.py
@@ -17,7 +17,7 @@ solution.
 
 import numpy as np
 from scipy import optimize
-import pylab as pl
+import matplotlib.pyplot as plt
 
 def f(x):
     return np.exp(-1/(.01*x[0]**2 + x[1]**2))
@@ -37,25 +37,25 @@ x_min = result.x
 ###############################################################################
 # Some pretty plotting
 
-pl.figure(0)
-pl.clf()
+plt.figure(0)
+plt.clf()
 t = np.linspace(-1.1, 1.1, 100)
-pl.plot(t, f([0, t]))
+plt.plot(t, f([0, t]))
 
-pl.figure(1)
-pl.clf()
+plt.figure(1)
+plt.clf()
 X, Y = np.mgrid[-1.5:1.5:100j, -1.1:1.1:100j]
-pl.imshow(f([X, Y]).T, cmap=pl.cm.gray_r, extent=[-1.5, 1.5, -1.1, 1.1],
+plt.imshow(f([X, Y]).T, cmap=plt.cm.gray_r, extent=[-1.5, 1.5, -1.1, 1.1],
           origin='lower')
-pl.contour(X, Y, f([X, Y]), cmap=pl.cm.gnuplot)
+plt.contour(X, Y, f([X, Y]), cmap=plt.cm.gnuplot)
 
 # Plot the gradient
 dX, dY = g_prime([.1*X[::5, ::5], Y[::5, ::5]])
 # Adjust for our preconditioning
 dX *= .1
-pl.quiver(X[::5, ::5], Y[::5, ::5], dX, dY, color='.5')
+plt.quiver(X[::5, ::5], Y[::5, ::5], dX, dY, color='.5')
 
 # Plot our solution
-pl.plot(x_min[0], x_min[1], 'r+', markersize=15)
+plt.plot(x_min[0], x_min[1], 'r+', markersize=15)
 
-pl.show()
+plt.show()

--- a/advanced/mathematical_optimization/examples/plot_exercise_ill_conditioned.py
+++ b/advanced/mathematical_optimization/examples/plot_exercise_ill_conditioned.py
@@ -11,7 +11,7 @@ import time
 
 import numpy as np
 from scipy import optimize
-import pylab as pl
+import matplotlib.pyplot as plt
 
 np.random.seed(0)
 
@@ -33,17 +33,17 @@ def hessian(x):
 ###############################################################################
 # Some pretty plotting
 
-pl.figure(1)
-pl.clf()
+plt.figure(1)
+plt.clf()
 Z = X, Y = np.mgrid[-1.5:1.5:100j, -1.1:1.1:100j]
 # Complete in the additional dimensions with zeros
 Z = np.reshape(Z, (2, -1)).copy()
 Z.resize((100, Z.shape[-1]))
 Z = np.apply_along_axis(f, 0, Z)
 Z = np.reshape(Z, X.shape)
-pl.imshow(Z.T, cmap=pl.cm.gray_r, extent=[-1.5, 1.5, -1.1, 1.1],
+plt.imshow(Z.T, cmap=plt.cm.gray_r, extent=[-1.5, 1.5, -1.1, 1.1],
           origin='lower')
-pl.contour(X, Y, Z, cmap=pl.cm.gnuplot)
+plt.contour(X, Y, Z, cmap=plt.cm.gnuplot)
 
 # A reference but slow solution:
 t0 = time.time()
@@ -81,4 +81,4 @@ print("     Newton: time %.2fs, x error %.2f, f error %.2f" % (
     time.time() - t0, np.sqrt(np.sum((x_newton - x_ref)**2)),
     f(x_newton) - f_ref))
 
-pl.show()
+plt.show()

--- a/advanced/mathematical_optimization/examples/plot_gradient_descent.py
+++ b/advanced/mathematical_optimization/examples/plot_gradient_descent.py
@@ -6,7 +6,7 @@ An example demoing gradient descent by creating figures that trace the
 evolution of the optimizer.
 """
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 from scipy import optimize
 
 import sys, os
@@ -191,49 +191,49 @@ for index, ((f, f_prime, hessian), optimizer) in enumerate((
     x = x.T
     y = y.T
 
-    pl.figure(index, figsize=(3, 2.5))
-    pl.clf()
-    pl.axes([0, 0, 1, 1])
+    plt.figure(index, figsize=(3, 2.5))
+    plt.clf()
+    plt.axes([0, 0, 1, 1])
 
     X = np.concatenate((x[np.newaxis, ...], y[np.newaxis, ...]), axis=0)
     z = np.apply_along_axis(f, 0, X)
     log_z = np.log(z + .01)
-    pl.imshow(log_z,
+    plt.imshow(log_z,
             extent=[x_min, x_max, y_min, y_max],
-            cmap=pl.cm.gray_r, origin='lower',
+            cmap=plt.cm.gray_r, origin='lower',
             vmax=log_z.min() + 1.5*log_z.ptp())
-    contours = pl.contour(log_z,
+    contours = plt.contour(log_z,
                         levels=levels.get(f, None),
                         extent=[x_min, x_max, y_min, y_max],
-                        cmap=pl.cm.gnuplot, origin='lower')
+                        cmap=plt.cm.gnuplot, origin='lower')
     levels[f] = contours.levels
-    pl.clabel(contours, inline=1,
+    plt.clabel(contours, inline=1,
                 fmt=super_fmt, fontsize=14)
 
-    pl.plot(all_x_i, all_y_i, 'b-', linewidth=2)
-    pl.plot(all_x_i, all_y_i, 'k+')
+    plt.plot(all_x_i, all_y_i, 'b-', linewidth=2)
+    plt.plot(all_x_i, all_y_i, 'k+')
 
-    pl.plot(logging_f.all_x_i, logging_f.all_y_i, 'k.', markersize=2)
+    plt.plot(logging_f.all_x_i, logging_f.all_y_i, 'k.', markersize=2)
 
-    pl.plot([0], [0], 'rx', markersize=12)
+    plt.plot([0], [0], 'rx', markersize=12)
 
 
-    pl.xticks(())
-    pl.yticks(())
-    pl.xlim(x_min, x_max)
-    pl.ylim(y_min, y_max)
-    pl.draw()
+    plt.xticks(())
+    plt.yticks(())
+    plt.xlim(x_min, x_max)
+    plt.ylim(y_min, y_max)
+    plt.draw()
 
-    pl.figure(index + 100, figsize=(4, 3))
-    pl.clf()
-    pl.semilogy(np.maximum(np.abs(all_f_i), 1e-30), linewidth=2,
+    plt.figure(index + 100, figsize=(4, 3))
+    plt.clf()
+    plt.semilogy(np.maximum(np.abs(all_f_i), 1e-30), linewidth=2,
                 label='# iterations')
-    pl.ylabel('Error on f(x)')
-    pl.semilogy(logging_f.counts,
+    plt.ylabel('Error on f(x)')
+    plt.semilogy(logging_f.counts,
                 np.maximum(np.abs(logging_f.all_f_i), 1e-30),
                 linewidth=2, color='g', label='# function calls')
-    pl.legend(loc='upper right', frameon=True, prop=dict(size=11),
+    plt.legend(loc='upper right', frameon=True, prop=dict(size=11),
               borderaxespad=0, handlelength=1.5, handletextpad=.5)
-    pl.tight_layout()
-    pl.draw()
+    plt.tight_layout()
+    plt.draw()
 

--- a/advanced/mathematical_optimization/examples/plot_noisy.py
+++ b/advanced/mathematical_optimization/examples/plot_noisy.py
@@ -5,7 +5,7 @@ Noisy optimization problem
 Draws a figure explaining noisy vs non-noisy optimization
 """
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 
 np.random.seed(0)
 
@@ -16,14 +16,14 @@ def f(x):
     return -np.exp(-x**2)
 
 # A smooth function
-pl.figure(1, figsize=(3, 2.5))
-pl.clf()
+plt.figure(1, figsize=(3, 2.5))
+plt.clf()
 
-pl.plot(x_, f(x_) + .2*np.random.normal(size=31), linewidth=2)
-pl.plot(x, f(x), linewidth=2)
+plt.plot(x_, f(x_) + .2*np.random.normal(size=31), linewidth=2)
+plt.plot(x, f(x), linewidth=2)
 
-pl.ylim(ymin=-1.3)
-pl.axis('off')
-pl.tight_layout()
-pl.show()
+plt.ylim(ymin=-1.3)
+plt.axis('off')
+plt.tight_layout()
+plt.show()
 

--- a/advanced/mathematical_optimization/examples/plot_non_bounds_constraints.py
+++ b/advanced/mathematical_optimization/examples/plot_non_bounds_constraints.py
@@ -6,37 +6,37 @@ An example showing how to do optimization with general constraints using
 SLSQP and cobyla.
 """
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 from scipy import optimize
 
 x, y = np.mgrid[-2.03:4.2:.04, -1.6:3.2:.04]
 x = x.T
 y = y.T
 
-pl.figure(1, figsize=(3, 2.5))
-pl.clf()
-pl.axes([0, 0, 1, 1])
+plt.figure(1, figsize=(3, 2.5))
+plt.clf()
+plt.axes([0, 0, 1, 1])
 
-contours = pl.contour(np.sqrt((x - 3)**2 + (y - 2)**2),
+contours = plt.contour(np.sqrt((x - 3)**2 + (y - 2)**2),
                     extent=[-2.03, 4.2, -1.6, 3.2],
-                    cmap=pl.cm.gnuplot)
-pl.clabel(contours,
+                    cmap=plt.cm.gnuplot)
+plt.clabel(contours,
         inline=1,
         fmt='%1.1f',
         fontsize=14)
-pl.plot([-1.5,    0,  1.5,    0, -1.5],
+plt.plot([-1.5,    0,  1.5,    0, -1.5],
         [   0,  1.5,    0, -1.5,    0], 'k', linewidth=2)
-pl.fill_between([ -1.5,    0,  1.5],
+plt.fill_between([ -1.5,    0,  1.5],
                 [    0, -1.5,    0],
                 [    0,  1.5,    0],
                 color='.8')
-pl.axvline(0, color='k')
-pl.axhline(0, color='k')
+plt.axvline(0, color='k')
+plt.axhline(0, color='k')
 
-pl.text(-.9, 2.8, '$x_2$', size=20)
-pl.text(3.6, -.6, '$x_1$', size=20)
-pl.axis('tight')
-pl.axis('off')
+plt.text(-.9, 2.8, '$x_2$', size=20)
+plt.text(3.6, -.6, '$x_1$', size=20)
+plt.axis('tight')
+plt.axis('off')
 
 # And now plot the optimization path
 accumulator = list()
@@ -54,6 +54,6 @@ optimize.minimize(f, np.array([0, 0]), method="SLSQP",
                      constraints={"fun": constraint, "type": "ineq"})
 
 accumulated = np.array(accumulator)
-pl.plot(accumulated[:, 0], accumulated[:, 1])
+plt.plot(accumulated[:, 0], accumulated[:, 1])
 
-pl.show()
+plt.show()

--- a/advanced/mathematical_optimization/examples/plot_smooth.py
+++ b/advanced/mathematical_optimization/examples/plot_smooth.py
@@ -5,28 +5,28 @@ Smooth vs non-smooth
 Draws a figure to explain smooth versus non smooth optimization.
 """
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 
 x = np.linspace(-1.5, 1.5, 101)
 
 # A smooth function
-pl.figure(1, figsize=(3, 2.5))
-pl.clf()
+plt.figure(1, figsize=(3, 2.5))
+plt.clf()
 
-pl.plot(x, np.sqrt(.2 + x**2), linewidth=2)
-pl.text(-1, 0, '$f$', size=20)
+plt.plot(x, np.sqrt(.2 + x**2), linewidth=2)
+plt.text(-1, 0, '$f$', size=20)
 
-pl.ylim(ymin=-.2)
-pl.axis('off')
-pl.tight_layout()
+plt.ylim(ymin=-.2)
+plt.axis('off')
+plt.tight_layout()
 
 # A non-smooth function
-pl.figure(2, figsize=(3, 2.5))
-pl.clf()
-pl.plot(x, np.abs(x), linewidth=2)
-pl.text(-1, 0, '$f$', size=20)
+plt.figure(2, figsize=(3, 2.5))
+plt.clf()
+plt.plot(x, np.abs(x), linewidth=2)
+plt.text(-1, 0, '$f$', size=20)
 
-pl.ylim(ymin=-.2)
-pl.axis('off')
-pl.tight_layout()
-pl.show()
+plt.ylim(ymin=-.2)
+plt.axis('off')
+plt.tight_layout()
+plt.show()

--- a/advanced/scipy_sparse/examples/lobpcg_sakurai.py
+++ b/advanced/scipy_sparse/examples/lobpcg_sakurai.py
@@ -9,7 +9,7 @@ from scipy import array, arange, ones, sort, cos, pi, rand, \
      set_printoptions, r_
 from scipy.sparse.linalg import lobpcg
 from scipy import sparse
-from pylab import loglog, show, xlabel, ylabel, title
+import matplotlib.pyplot as plt
 set_printoptions(precision=8,linewidth=90)
 import time
 
@@ -51,8 +51,8 @@ print
 print w_ex[:m]
 print
 print 'Elapsed time',data[0]
-loglog(arange(1,n+1),w_ex,'b.')
-xlabel(r'Number $i$')
-ylabel(r'$\lambda_i$')
-title('Eigenvalue distribution')
-show()
+plt.loglog(arange(1,n+1),w_ex,'b.')
+plt.xlabel(r'Number $i$')
+plt.ylabel(r'$\lambda_i$')
+plt.title('Eigenvalue distribution')
+plt.show()

--- a/advanced/scipy_sparse/examples/pyamg_with_lobpcg.py
+++ b/advanced/scipy_sparse/examples/pyamg_with_lobpcg.py
@@ -9,6 +9,7 @@ Dirichlet boundary conditions.
 
 import scipy
 from scipy.sparse.linalg import lobpcg
+import matplotlib.pyplot as plt
 
 from pyamg import smoothed_aggregation_solver
 from pyamg.gallery import poisson
@@ -31,14 +32,12 @@ W,V = lobpcg(A, X, M=M, tol=1e-8, largest=False)
 
 
 #plot the eigenvectors
-import pylab
-
-pylab.figure(figsize=(9,9))
+plt.figure(figsize=(9,9))
 
 for i in range(K):
-    pylab.subplot(3, 3, i+1)
-    pylab.title('Eigenvector %d' % i)
-    pylab.pcolor(V[:,i].reshape(N,N))
-    pylab.axis('equal')
-    pylab.axis('off')
-pylab.show()    
+    plt.subplot(3, 3, i+1)
+    plt.title('Eigenvector %d' % i)
+    plt.pcolor(V[:,i].reshape(N,N))
+    plt.axis('equal')
+    plt.axis('off')
+plt.show()    

--- a/intro/matplotlib/index.rst
+++ b/intro/matplotlib/index.rst
@@ -92,7 +92,7 @@ values).
 
 To run the example, you can type them in an IPython interactive session::
 
-    $ ipython --pylab
+    $ ipython --matplotlib
 
 This brings us to the IPython prompt: ::
 
@@ -101,9 +101,6 @@ This brings us to the IPython prompt: ::
     %magic  -> Information about IPython's 'magic' % functions.
     help    -> Python's own help system.
     object? -> Details about 'object'. ?object also works, ?? prints more.
-
-    Welcome to pylab, a matplotlib-based Python environment.
-    For more information, type 'help(pylab)'.
 
 .. tip::
 

--- a/intro/numpy/exercises.rst
+++ b/intro/numpy/exercises.rst
@@ -58,11 +58,11 @@ use different colormaps, crop the image, change some parts of the image.
 .. image:: images/faces.png
     :align: center
 
-* Let's use the imshow function of pylab to display the image.
+* Let's use the imshow function of matplotlib to display the image.
 
     .. sourcecode:: pycon
 
-        >>> import pylab as plt
+        >>> import matplotlib.pyplot as plt
         >>> face = misc.face(gray=True)
         >>> plt.imshow(face)    # doctest: +ELLIPSIS
         <matplotlib.image.AxesImage object at 0x...>

--- a/intro/scipy.rst
+++ b/intro/scipy.rst
@@ -539,8 +539,8 @@ We can constrain the variable to the interval
     Hints:
 
         - Variables can be restricted to :math:`-2 < x < 2` and :math:`-1 < y < 1`.
-        - Use :func:`numpy.meshgrid` and :func:`pylab.imshow` to find visually the
-          regions.
+        - Use :func:`numpy.meshgrid` and :func:`matplotlib.pyplot.imshow` to
+          find visually the regions.
         - Use :func:`scipy.optimize.minimize`, optionally trying out
           several of its `methods'.
 
@@ -964,7 +964,7 @@ Crude periodicity finding (:ref:`link <sphx_glr_intro_scipy_auto_examples_soluti
       noise. In this exercise, we aim to clean up the noise using the
       Fast Fourier Transform.
 
-   2. Load the image using :func:`pylab.imread`.
+   2. Load the image using :func:`matplotlib.pyplot.imread`.
 
    3. Find and use the 2-D FFT function in :mod:`scipy.fftpack`, and plot the
       spectrum (Fourier transform of) the image. Do you have any trouble

--- a/intro/summary-exercises/answers_image_processing.rst
+++ b/intro/summary-exercises/answers_image_processing.rst
@@ -2,7 +2,7 @@
 .. only:: html
 
     >>> import numpy as np
-    >>> import pylab as pl
+    >>> import matplotlib.pyplot as plt
     >>> from scipy import ndimage
 
 .. _image-answers:
@@ -19,7 +19,7 @@ Example of solution for the image processing exercise: unmolten grains in glass
    with the "right" orientation (origin in the bottom left corner, and not
    the upper left corner as for standard arrays). ::
 
-    >>> dat = pl.imread('data/MV_HFV_012.jpg')
+    >>> dat = plt.imread('data/MV_HFV_012.jpg')
 
 2. Crop the image to remove the lower panel with measure information. ::
 

--- a/intro/summary-exercises/examples/plot_cumulative_wind_speed_prediction.py
+++ b/intro/summary-exercises/examples/plot_cumulative_wind_speed_prediction.py
@@ -8,7 +8,7 @@ for the interpolate section of scipy.rst.
 
 import numpy as np
 from scipy.interpolate import UnivariateSpline
-import pylab as pl
+import matplotlib.pyplot as plt
 
 max_speeds = np.load('max-speeds.npy')
 years_nb = max_speeds.shape[0]
@@ -22,11 +22,11 @@ fitted_max_speeds = speed_spline(nprob)
 fifty_prob = 1. - 0.02
 fifty_wind = speed_spline(fifty_prob)
 
-pl.figure()
-pl.plot(sorted_max_speeds, cprob, 'o')
-pl.plot(fitted_max_speeds, nprob, 'g--')
-pl.plot([fifty_wind], [fifty_prob], 'o', ms=8., mfc='y', mec='y')
-pl.text(30, 0.05, '$V_{50} = %.2f \, m/s$' % fifty_wind)
-pl.plot([fifty_wind, fifty_wind], [pl.axis()[2], fifty_prob], 'k--')
-pl.xlabel('Annual wind speed maxima [$m/s$]')
-pl.ylabel('Cumulative probability')
+plt.figure()
+plt.plot(sorted_max_speeds, cprob, 'o')
+plt.plot(fitted_max_speeds, nprob, 'g--')
+plt.plot([fifty_wind], [fifty_prob], 'o', ms=8., mfc='y', mec='y')
+plt.text(30, 0.05, '$V_{50} = %.2f \, m/s$' % fifty_wind)
+plt.plot([fifty_wind, fifty_wind], [plt.axis()[2], fifty_prob], 'k--')
+plt.xlabel('Annual wind speed maxima [$m/s$]')
+plt.ylabel('Cumulative probability')

--- a/intro/summary-exercises/examples/plot_gumbell_wind_speed_prediction.py
+++ b/intro/summary-exercises/examples/plot_gumbell_wind_speed_prediction.py
@@ -6,7 +6,7 @@ Generate the exercise results on the Gumbell distribution
 """
 import numpy as np
 from scipy.interpolate import UnivariateSpline
-import pylab as pl
+import matplotlib.pyplot as plt
 
 
 def gumbell_dist(arr):
@@ -26,12 +26,12 @@ fitted_max_speeds = speed_spline(nprob)
 fifty_prob = gumbell_dist(49./50.)
 fifty_wind = speed_spline(fifty_prob)
 
-pl.figure()
-pl.plot(sorted_max_speeds, gprob, 'o')
-pl.plot(fitted_max_speeds, nprob, 'g--')
-pl.plot([fifty_wind], [fifty_prob], 'o', ms=8., mfc='y', mec='y')
-pl.plot([fifty_wind, fifty_wind], [pl.axis()[2], fifty_prob], 'k--')
-pl.text(35, -1, r'$V_{50} = %.2f \, m/s$' % fifty_wind)
-pl.xlabel('Annual wind speed maxima [$m/s$]')
-pl.ylabel('Gumbell cumulative probability')
-pl.show()
+plt.figure()
+plt.plot(sorted_max_speeds, gprob, 'o')
+plt.plot(fitted_max_speeds, nprob, 'g--')
+plt.plot([fifty_wind], [fifty_prob], 'o', ms=8., mfc='y', mec='y')
+plt.plot([fifty_wind, fifty_wind], [plt.axis()[2], fifty_prob], 'k--')
+plt.text(35, -1, r'$V_{50} = %.2f \, m/s$' % fifty_wind)
+plt.xlabel('Annual wind speed maxima [$m/s$]')
+plt.ylabel('Gumbell cumulative probability')
+plt.show()

--- a/intro/summary-exercises/examples/plot_sprog_annual_maxima.py
+++ b/intro/summary-exercises/examples/plot_sprog_annual_maxima.py
@@ -6,7 +6,7 @@ Generate the exercise results on the Gumbell distribution
 """
 import numpy as np
 from scipy.interpolate import UnivariateSpline
-import pylab as pl
+import matplotlib.pyplot as plt
 
 
 def gumbell_dist(arr):
@@ -26,8 +26,8 @@ fitted_max_speeds = speed_spline(nprob)
 fifty_prob = gumbell_dist(49./50.)
 fifty_wind = speed_spline(fifty_prob)
 
-pl.figure()
-pl.bar(np.arange(years_nb) + 1, max_speeds)
-pl.axis('tight')
-pl.xlabel('Year')
-pl.ylabel('Annual wind speed maxima [$m/s$]')
+plt.figure()
+plt.bar(np.arange(years_nb) + 1, max_speeds)
+plt.axis('tight')
+plt.xlabel('Year')
+plt.ylabel('Annual wind speed maxima [$m/s$]')

--- a/packages/scikit-learn/examples/plot_ML_flow_chart.py
+++ b/packages/scikit-learn/examples/plot_ML_flow_chart.py
@@ -6,15 +6,15 @@ This script plots the flow-charts used in the scikit-learn tutorials.
 """
 
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 from matplotlib.patches import Circle, Rectangle, Polygon, Arrow, FancyArrow
 
 def create_base(box_bg = '#CCCCCC',
                 arrow1 = '#88CCFF',
                 arrow2 = '#88FF88',
                 supervised=True):
-    fig = pl.figure(figsize=(9, 6), facecolor='w')
-    ax = pl.axes((0, 0, 1, 1),
+    fig = plt.figure(figsize=(9, 6), facecolor='w')
+    ax = plt.axes((0, 0, 1, 1),
                  xticks=[], yticks=[], frameon=False)
     ax.set_xlim(0, 9)
     ax.set_ylim(0, 6)
@@ -69,38 +69,38 @@ def create_base(box_bg = '#CCCCCC',
     for p in patches:
         ax.add_patch(p)
         
-    pl.text(1.45, 4.9, "Training\nText,\nDocuments,\nImages,\netc.",
+    plt.text(1.45, 4.9, "Training\nText,\nDocuments,\nImages,\netc.",
             ha='center', va='center', fontsize=14)
     
-    pl.text(3.6, 4.9, "Feature\nVectors", 
+    plt.text(3.6, 4.9, "Feature\nVectors", 
             ha='left', va='center', fontsize=14)
     
-    pl.text(5.5, 3.5, "Machine\nLearning\nAlgorithm",
+    plt.text(5.5, 3.5, "Machine\nLearning\nAlgorithm",
             ha='center', va='center', fontsize=14)
     
-    pl.text(1.05, 1.1, "New Text,\nDocument,\nImage,\netc.",
+    plt.text(1.05, 1.1, "New Text,\nDocument,\nImage,\netc.",
             ha='center', va='center', fontsize=14)
     
-    pl.text(3.3, 1.7, "Feature\nVector", 
+    plt.text(3.3, 1.7, "Feature\nVector", 
             ha='left', va='center', fontsize=14)
     
-    pl.text(5.5, 1.1, "Predictive\nModel", 
+    plt.text(5.5, 1.1, "Predictive\nModel", 
             ha='center', va='center', fontsize=12)
 
     if supervised:
-        pl.text(1.45, 3.05, "Labels",
+        plt.text(1.45, 3.05, "Labels",
                 ha='center', va='center', fontsize=14)
     
-        pl.text(8.05, 1.1, "Expected\nLabel",
+        plt.text(8.05, 1.1, "Expected\nLabel",
                 ha='center', va='center', fontsize=14)
-        pl.text(8.8, 5.8, "Supervised Learning Model",
+        plt.text(8.8, 5.8, "Supervised Learning Model",
                 ha='right', va='top', fontsize=18)
 
     else:
-        pl.text(8.05, 1.1,
+        plt.text(8.05, 1.1,
                 "Likelihood\nor Cluster ID\nor Better\nRepresentation",
                 ha='center', va='center', fontsize=12)
-        pl.text(8.8, 5.8, "Unsupervised Learning Model",
+        plt.text(8.8, 5.8, "Unsupervised Learning Model",
                 ha='right', va='top', fontsize=18)
         
         
@@ -109,16 +109,16 @@ def plot_supervised_chart(annotate=False):
     create_base(supervised=True)
     if annotate:
         fontdict = dict(color='r', weight='bold', size=14)
-        pl.text(1.9, 4.55, 'X = vec.fit_transform(input)',
+        plt.text(1.9, 4.55, 'X = vec.fit_transform(input)',
                 fontdict=fontdict,
                 rotation=20, ha='left', va='bottom')
-        pl.text(3.7, 3.2, 'clf.fit(X, y)',
+        plt.text(3.7, 3.2, 'clf.fit(X, y)',
                 fontdict=fontdict,
                 rotation=20, ha='left', va='bottom')
-        pl.text(1.7, 1.5, 'X_new = vec.transform(input)',
+        plt.text(1.7, 1.5, 'X_new = vec.transform(input)',
                 fontdict=fontdict,
                 rotation=20, ha='left', va='bottom')
-        pl.text(6.1, 1.5, 'y_new = clf.predict(X_new)',
+        plt.text(6.1, 1.5, 'y_new = clf.predict(X_new)',
                 fontdict=fontdict,
                 rotation=20, ha='left', va='bottom')
 
@@ -130,6 +130,6 @@ if __name__ == '__main__':
     plot_supervised_chart(False)
     plot_supervised_chart(True)
     plot_unsupervised_chart()
-    pl.show()
+    plt.show()
 
 

--- a/packages/scikit-learn/index.rst
+++ b/packages/scikit-learn/index.rst
@@ -728,7 +728,7 @@ The ``DESCR`` variable has a long description of the dataset::
     ...
 
 It often helps to quickly visualize pieces of the data using histograms,
-scatter plots, or other plot types. With pylab, let us show a
+scatter plots, or other plot types. With matplotlib, let us show a
 histogram of the target values: the median price in each neighborhood::
 
     >>> plt.hist(data.target)  # doctest: +ELLIPSIS


### PR DESCRIPTION
Some search and replace of `pylab` with `matplotlib.pyplot` (I don't think we should still encourage to use `pylab`?)

The main actual change in the explanation is changing the recommendation of `$ ipython --pylab` to `$ ipython --matplotlib` (as I think the `--pylab` one still silently imports libraries as well). Another option would be to mention to do `%matplotlib` manually.