### PR TITLE
make cos_module_np 2/3 compatible

### DIFF
--- a/advanced/interfacing_with_c/numpy_c_api/cos_module_np.c
+++ b/advanced/interfacing_with_c/numpy_c_api/cos_module_np.c
@@ -72,11 +72,36 @@ static PyMethodDef CosMethods[] =
      {NULL, NULL, 0, NULL}
 };
 
+
+#if PY_MAJOR_VERSION >= 3
 /* module initialization */
-PyMODINIT_FUNC
-initcos_module_np(void)
-{
-     (void) Py_InitModule("cos_module_np", CosMethods);
-     /* IMPORTANT: this must be called */
-     import_array();
+/* Python version 3*/
+static struct PyModuleDef cModPyDem = {
+    PyModuleDef_HEAD_INIT,
+    "cos_module", "Some documentation",
+    -1,
+    CosMethods
+};
+PyMODINIT_FUNC PyInit_cos_module_np(void) {
+    PyObject *module;
+    module = PyModule_Create(&cModPyDem);
+    if(module==NULL) return NULL;
+    /* IMPORTANT: this must be called */
+    import_array();
+    if (PyErr_Occurred()) return NULL;
+    return module;
 }
+
+#else
+/* module initialization */
+/* Python version 2 */
+PyMODINIT_FUNC initcos_module_np(void) {
+    PyObject *module;
+    module = Py_InitModule("cos_module_np", CosMethods);
+    if(module==NULL) return;
+    /* IMPORTANT: this must be called */
+    import_array();
+    return;
+}
+
+#endif


### PR DESCRIPTION
As in 258d192b, the numpy C-API code needs to be updated to work with both python 2 and 3.  For stylistic reasons, I tried to follow that previous commit as closely as possible — but there are additional changes needed for numpy that make the difference a little more extensive.