### PR TITLE
Update to renaming in pandas 0.15

### DIFF
--- a/packages/statistics/examples/plot_iris_analysis.py
+++ b/packages/statistics/examples/plot_iris_analysis.py
@@ -27,7 +27,7 @@ data = pandas.read_csv('iris.csv')
 categories = pandas.Categorical(data['name'])
 
 # The parameter 'c' is passed to plt.scatter and will control the color
-plotting.scatter_matrix(data, c=categories.labels, marker='o')
+plotting.scatter_matrix(data, c=categories.codes, marker='o')
 
 fig = plt.gcf()
 fig.suptitle("blue: setosa, green: versicolor, red: virginica", size=13)


### PR DESCRIPTION
The environment.yml file asks for pandas 0.20. There was change back in version 0.15.  

Rename `categorical_instance.labels` to `categorical_instance.codes` (pandas >= 0.15)

See: https://github.com/pandas-dev/pandas/blob/master/doc/source/whatsnew/v0.15.0.txt
     The ``Categorical.labels`` attribute was renamed to ``Categorical.codes``.