### PR TITLE
1.2.5.4. ‘__main__’ and module loading

### DIFF
--- a/intro/language/reusing_code.rst
+++ b/intro/language/reusing_code.rst
@@ -294,13 +294,11 @@ Importing it:
     In [11]: import demo2
     b
 
-    In [12]: import demo2
-
 Running it:
 
 .. sourcecode:: ipython
 
-    In [13]: %run demo2
+    In [12]: %run demo2
     b
     a
 


### PR DESCRIPTION
this section had a small issue with In [12]. I have removed the line.