### PR TITLE
Small additions

### DIFF
--- a/intro/intro.rst
+++ b/intro/intro.rst
@@ -352,6 +352,8 @@ will get you far. Here are several good easy-to-use editors:
   * `PyCharm <https://www.jetbrains.com/pycharm>`_: integrates an IPython
     console, notebooks, a debugger... (freely available,
     but commercial)
+  * `Visual Studio Code <https://code.visualstudio.com/docs/languages/python>`_:
+    itegrates a Python console, notebooks, a debugger, ...
   * `Atom <https://atom.io>`_
 
 Some of these are shipped by the various scientific Python distributions,

--- a/intro/language/first_steps.rst
+++ b/intro/language/first_steps.rst
@@ -9,6 +9,12 @@ Start the **Ipython** shell (an enhanced interactive Python shell):
   `EPD`_ menu if you have installed one of these scientific-Python suites.
 
 .. _`Python(x,y)`: https://python-xy.github.io/
+* **or** by starting the program from a menu, e.g. the `Anaconda Navigator`_,
+  the `Python(x,y)`_ menu or the `EPD`_ menu if you have installed one of these
+  scientific-Python suites.
+
+.. _`Anaconda Navigator`: https://anaconda.org/anaconda/anaconda-navigator
+.. _`Python(x,y)`: http://www.pythonxy.com/
 .. _`EPD`: http://store.enthought.com/
 
 .. tip::

--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -370,13 +370,13 @@ Start by launching IPython:
 
 .. sourcecode:: bash
 
-    $ ipython
+    $ ipython # or ipython3 depending on your install
 
 Or the notebook:
 
 .. sourcecode:: bash
 
-   $ ipython notebook
+   $ jupyter notebook
 
 Once IPython has started, enable interactive plots:
 


### PR DESCRIPTION
Most of the changes reflect the fact, that ipython3 (not ipython) needs to be executed in Linux to get IPython with Python 3.

Plus the removal of trailing whitespace.