### PR TITLE
deprecated keyword argument replaced

### DIFF
--- a/intro/scipy.rst
+++ b/intro/scipy.rst
@@ -631,7 +631,7 @@ the random process's PDF (probability density function): ::
     >>> bins = np.arange(-4, 5)
     >>> bins
     array([-4, -3, -2, -1,  0,  1,  2,  3,  4])
-    >>> histogram = np.histogram(samples, bins=bins, normed=True)[0]
+    >>> histogram = np.histogram(samples, bins=bins, density=True)[0]
     >>> bins = 0.5*(bins[1:] + bins[:-1])
     >>> bins
     array([-3.5, -2.5, -1.5, -0.5,  0.5,  1.5,  2.5,  3.5])

--- a/intro/scipy/examples/plot_normal_distribution.py
+++ b/intro/scipy/examples/plot_normal_distribution.py
@@ -14,7 +14,7 @@ samples = np.random.normal(size=10000)
 
 # Compute a histogram of the sample
 bins = np.linspace(-5, 5, 30)
-histogram, bins = np.histogram(samples, bins=bins, normed=True)
+histogram, bins = np.histogram(samples, bins=bins, density=True)
 
 bin_centers = 0.5*(bins[1:] + bins[:-1])
 

--- a/intro/scipy/examples/plot_t_test.py
+++ b/intro/scipy/examples/plot_t_test.py
@@ -18,8 +18,8 @@ histogram1, bins = np.histogram(samples1, bins=bins, density=True)
 histogram2, bins = np.histogram(samples2, bins=bins, density=True)
 
 plt.figure(figsize=(6, 4))
-plt.hist(samples1, bins=bins, normed=True, label="Samples 1")
-plt.hist(samples2, bins=bins, normed=True, label="Samples 2")
+plt.hist(samples1, bins=bins, density=True, label="Samples 1")
+plt.hist(samples2, bins=bins, density=True, label="Samples 2")
 plt.legend(loc='best')
 plt.show()
 

--- a/intro/scipy/examples/plot_t_test.py
+++ b/intro/scipy/examples/plot_t_test.py
@@ -14,8 +14,8 @@ samples2 = np.random.normal(1, size=1000)
 
 # Compute a histogram of the sample
 bins = np.linspace(-4, 4, 30)
-histogram1, bins = np.histogram(samples1, bins=bins, normed=True)
-histogram2, bins = np.histogram(samples2, bins=bins, normed=True)
+histogram1, bins = np.histogram(samples1, bins=bins, density=True)
+histogram2, bins = np.histogram(samples2, bins=bins, density=True)
 
 plt.figure(figsize=(6, 4))
 plt.hist(samples1, bins=bins, normed=True, label="Samples 1")


### PR DESCRIPTION
This PR takes care of the deprecated keyword argument ``normed`` of  ``np.histogram`` pointed out in #439. A related deprecation applies to ``plt.hist`` since ``matplotlib 2.2`` which we presently use to build the lecture notes. Therefore, this PR also replaces ``normed`` by ``density`` in calls to ``plt.hist``.