### PR TITLE
remove endpoint=True from np.linspace()

### DIFF
--- a/intro/matplotlib/examples/exercises/plot_exercise_1.py
+++ b/intro/matplotlib/examples/exercises/plot_exercise_1.py
@@ -9,7 +9,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 n = 256
-X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+X = np.linspace(-np.pi, np.pi, 256)
 C,S = np.cos(X), np.sin(X)
 plt.plot(X, C)
 plt.plot(X,S)

--- a/intro/matplotlib/examples/exercises/plot_exercise_10.py
+++ b/intro/matplotlib/examples/exercises/plot_exercise_10.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 plt.figure(figsize=(8, 5), dpi=80)
 plt.subplot(111)
 
-X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+X = np.linspace(-np.pi, np.pi, 256)
 C, S = np.cos(X), np.sin(X)
 
 plt.plot(X, C, color="blue", linewidth=2.5, linestyle="-", label="cosine")

--- a/intro/matplotlib/examples/exercises/plot_exercise_2.py
+++ b/intro/matplotlib/examples/exercises/plot_exercise_2.py
@@ -14,7 +14,7 @@ plt.figure(figsize=(8, 6), dpi=80)
 # Create a new subplot from a grid of 1x1
 plt.subplot(111)
 
-X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+X = np.linspace(-np.pi, np.pi, 256)
 C, S = np.cos(X), np.sin(X)
 
 # Plot cosine using blue color with a continuous line of width 1 (pixels)
@@ -27,13 +27,13 @@ plt.plot(X, S, color="green", linewidth=1.0, linestyle="-")
 plt.xlim(-4., 4.)
 
 # Set x ticks
-plt.xticks(np.linspace(-4, 4, 9, endpoint=True))
+plt.xticks(np.linspace(-4, 4, 9))
 
 # Set y limits
 plt.ylim(-1.0, 1.0)
 
 # Set y ticks
-plt.yticks(np.linspace(-1, 1, 5, endpoint=True))
+plt.yticks(np.linspace(-1, 1, 5))
 
 # Show result on screen
 plt.show()

--- a/intro/matplotlib/examples/exercises/plot_exercise_3.py
+++ b/intro/matplotlib/examples/exercises/plot_exercise_3.py
@@ -11,16 +11,16 @@ import matplotlib.pyplot as plt
 plt.figure(figsize=(8, 5), dpi=80)
 plt.subplot(111)
 
-X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+X = np.linspace(-np.pi, np.pi, 256)
 C, S = np.cos(X), np.sin(X)
 
 plt.plot(X, C, color="blue", linewidth=2.5, linestyle="-")
 plt.plot(X, S, color="red", linewidth=2.5, linestyle="-")
 
 plt.xlim(-4.0, 4.0)
-plt.xticks(np.linspace(-4, 4, 9, endpoint=True))
+plt.xticks(np.linspace(-4, 4, 9))
 
 plt.ylim(-1.0, 1.0)
-plt.yticks(np.linspace(-1, 1, 5, endpoint=True))
+plt.yticks(np.linspace(-1, 1, 5))
 
 plt.show()

--- a/intro/matplotlib/examples/exercises/plot_exercise_4.py
+++ b/intro/matplotlib/examples/exercises/plot_exercise_4.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 plt.figure(figsize=(8, 5), dpi=80)
 plt.subplot(111)
 
-X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+X = np.linspace(-np.pi, np.pi, 256)
 S = np.sin(X)
 C = np.cos(X)
 

--- a/intro/matplotlib/examples/exercises/plot_exercise_5.py
+++ b/intro/matplotlib/examples/exercises/plot_exercise_5.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 plt.figure(figsize=(8, 5), dpi=80)
 plt.subplot(111)
 
-X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+X = np.linspace(-np.pi, np.pi, 256)
 S = np.sin(X)
 C = np.cos(X)
 

--- a/intro/matplotlib/examples/exercises/plot_exercise_6.py
+++ b/intro/matplotlib/examples/exercises/plot_exercise_6.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 plt.figure(figsize=(8, 5), dpi=80)
 plt.subplot(111)
 
-X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+X = np.linspace(-np.pi, np.pi, 256)
 C = np.cos(X)
 S = np.sin(X)
 

--- a/intro/matplotlib/examples/plot_bad.py
+++ b/intro/matplotlib/examples/plot_bad.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 
 fig = plt.figure(figsize=(5, 4), dpi=72)
 axes = fig.add_axes([0.01, 0.01, .98, 0.98])
-x = np.linspace(0, 2, 200, endpoint=True)
+x = np.linspace(0, 2, 200)
 y = np.sin(2 * np.pi * x)
 plt.plot(x, y, lw=.25, c='k')
 plt.xticks(np.arange(0.0, 2.0, 0.1))

--- a/intro/matplotlib/examples/plot_good.py
+++ b/intro/matplotlib/examples/plot_good.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 
 fig = plt.figure(figsize=(5, 4), dpi=72)
 axes = fig.add_axes([0.01, 0.01, .98, 0.98])
-X = np.linspace(0, 2, 200, endpoint=True)
+X = np.linspace(0, 2, 200)
 Y = np.sin(2*np.pi*X)
 plt.plot(X, Y, lw=2)
 plt.ylim(-1.1, 1.1)

--- a/intro/matplotlib/examples/plot_plot.py
+++ b/intro/matplotlib/examples/plot_plot.py
@@ -9,7 +9,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 n = 256
-X = np.linspace(-np.pi, np.pi, n, endpoint=True)
+X = np.linspace(-np.pi, np.pi, n)
 Y = np.sin(2 * X)
 
 plt.axes([0.025, 0.025, 0.95, 0.95])

--- a/intro/matplotlib/examples/plot_ugly.py
+++ b/intro/matplotlib/examples/plot_ugly.py
@@ -14,7 +14,7 @@ matplotlib.rc('grid', color='black', linestyle='-', linewidth=1)
 
 fig = plt.figure(figsize=(5,4),dpi=72)
 axes = fig.add_axes([0.01, 0.01, .98, 0.98], facecolor='.75')
-X = np.linspace(0, 2, 40, endpoint=True)
+X = np.linspace(0, 2, 40)
 Y = np.sin(2 * np.pi * X)
 plt.plot(X, Y, lw=.05, c='b', antialiased=False)
 

--- a/intro/matplotlib/examples/pretty_plots/plot_boxplot_ext.py
+++ b/intro/matplotlib/examples/pretty_plots/plot_boxplot_ext.py
@@ -15,7 +15,7 @@ axes = plt.subplot(111)
 
 n = 5
 Z = np.zeros((n, 4))
-X = np.linspace(0, 2, n, endpoint=True)
+X = np.linspace(0, 2, n)
 Y = np.random.random((n, 4))
 plt.boxplot(Y)
 

--- a/intro/matplotlib/index.rst
+++ b/intro/matplotlib/index.rst
@@ -82,7 +82,7 @@ Simple plot
 
    import numpy as np
 
-   X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+   X = np.linspace(-np.pi, np.pi, 256)
    C, S = np.cos(X), np.sin(X)
 
 
@@ -140,7 +140,7 @@ Plotting with default settings
    import numpy as np
    import matplotlib.pyplot as plt
 
-   X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+   X = np.linspace(-np.pi, np.pi, 256)
    C, S = np.cos(X), np.sin(X)
 
    plt.plot(X, C)
@@ -183,7 +183,7 @@ that influence the appearance of the plot.
    # Create a new subplot from a grid of 1x1
    plt.subplot(1, 1, 1)
 
-   X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+   X = np.linspace(-np.pi, np.pi, 256)
    C, S = np.cos(X), np.sin(X)
 
    # Plot cosine with a blue continuous line of width 1 (pixels)
@@ -196,13 +196,13 @@ that influence the appearance of the plot.
    plt.xlim(-4.0, 4.0)
 
    # Set x ticks
-   plt.xticks(np.linspace(-4, 4, 9, endpoint=True))
+   plt.xticks(np.linspace(-4, 4, 9))
 
    # Set y limits
    plt.ylim(-1.0, 1.0)
 
    # Set y ticks
-   plt.yticks(np.linspace(-1, 1, 5, endpoint=True))
+   plt.yticks(np.linspace(-1, 1, 5))
 
    # Save figure using 72 dots per inch
    # plt.savefig("exercise_2.png", dpi=72)
@@ -702,7 +702,7 @@ care of filled areas:
 ::
 
    n = 256
-   X = np.linspace(-np.pi, np.pi, n, endpoint=True)
+   X = np.linspace(-np.pi, np.pi, n)
    Y = np.sin(2 * X)
 
    plt.plot(X, Y + 1, color='blue', alpha=1.00)


### PR DESCRIPTION
There is no need to specify this explicitly because it is already the
default behavior.