### PR TITLE
fixed most of the broken links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 What's new
 ==========
 
+* Fix outdated URLs (Gert-Ludwig Ingold)
+
 Release 2019.1 (May 2019)
 -------------------------
 

--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -1619,7 +1619,7 @@ Contributing to documentation
 
        - "change your subscription options", at the bottom of 
 
-         http://mail.scipy.org/mailman/listinfo/scipy-dev
+         http://mail.python.org/mailman/listinfo/scipy-dev
 
      - Send a mail @ ``scipy-dev`` mailing list; ask for activation::
 

--- a/advanced/advanced_python/index.rst
+++ b/advanced/advanced_python/index.rst
@@ -1011,7 +1011,7 @@ leaving only the interesting ``do_something`` block.
    returned by ``__enter__`` is simply ignored.
 2. The block of code underneath ``with`` is executed.  Just like with
    ``try`` clauses, it can either execute successfully to the end, or
-   it can :simple:`break`, :simple:`continue`` or :simple:`return`, or
+   it can :simple:`break`, :simple:`continue` or :simple:`return`, or
    it can throw an exception. Either way, after the block is finished,
    the `__exit__ <object.__exit__>` method is called.
    If an exception was thrown, the information about the exception is

--- a/advanced/interfacing_with_c/interfacing_with_c.rst
+++ b/advanced/interfacing_with_c/interfacing_with_c.rst
@@ -835,7 +835,7 @@ Further Reading and References
 ==============================
 
 * `Gaël Varoquaux's blog post about avoiding data copies
-  <http://gael-varoquaux.info/blog/?p=157>`_ provides some insight on how to
+  <http://gael-varoquaux.info/programming/cython-example-of-exposing-c-computed-arrays-in-python-without-data-copies.html>`_ provides some insight on how to
   handle memory management cleverly. If you ever run into issues with large
   datasets, this is a reference to come back to for some inspiration.
 

--- a/advanced/interfacing_with_c/interfacing_with_c.rst
+++ b/advanced/interfacing_with_c/interfacing_with_c.rst
@@ -755,8 +755,8 @@ the Numpy array type to your Cython code. I.e. like specifying that variable
 bounds checking are supported. Look at the corresponding section in the `Cython
 documentation <http://docs.cython.org/src/tutorial/numpy.html>`_. In case you
 want to pass Numpy arrays as C arrays to your Cython wrapped C functions, there
-is a section about this in the `Cython wiki
-<http://wiki.cython.org/tutorials/NumpyPointerToC>`_.
+is a section about this in the `Cython documentation
+<http://docs.cython.org/src/userguide/memoryviews.html#pass-data-from-a-c-function-via-pointer>`_.
 
 In the following example, we will show how to wrap the familiar ``cos_doubles``
 function using Cython.

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -1025,7 +1025,7 @@ and :math:`g(x) < 0`.
 .. warning:: 
    
    The above problem is known as the `Lasso
-   <http://en.wikipedia.org/wiki/Lasso_(statistics)#LASSO_method>`_
+   <http://en.wikipedia.org/wiki/Lasso_(statistics)>`_
    problem in statistics, and there exist very efficient solvers for it
    (for instance in `scikit-learn <http://scikit-learn.org>`_). In
    general do not use generic solvers when specific ones exist.

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -154,7 +154,7 @@ documentation of the various packages. You should link as much as
 possible to the original documentation.
 
 For cross-referencing API documentation we prefer to use the `intersphinx
-extension <http://www.sphinx-doc.org/en/master/usage/extensions/index.html#builtin-sphinx-extensions>`_. This provides
+extension <http://www.sphinx-doc.org/en/master/usage/extensions/index.html#built-in-extensions>`_. This provides
 the directives `:mod:`, `:class:` and `:func:` to cross-link to modules,
 classes and functions respectively. For example the ``:func:`numpy.var``` will
 create a link like :func:`numpy.var`.

--- a/intro/help/help.rst
+++ b/intro/help/help.rst
@@ -57,7 +57,7 @@ just to display help and docstrings...
 
   |clear-floats|
 
-* Scipy central http://central.scipy.org/ gives recipes on many
+* The SciPy Cookbook https://scipy-cookbook.readthedocs.io gives recipes on many
   common problems frequently encountered, such as fitting data points,
   solving ODE, etc. 
 

--- a/intro/intro.rst
+++ b/intro/intro.rst
@@ -130,7 +130,7 @@ Python
 
   * A variety of powerful environments to work in, such as
     `IPython <http://ipython.readthedocs.io/en/stable/>`__,
-    `Spyder <https://pythonhosted.org/spyder>`__,
+    `Spyder <https://www.spyder-ide.org/>`__,
     `Jupyter notebooks <http://jupyter.org/>`__,
     `Pycharm <https://www.jetbrains.com/pycharm>`__,
     `Visual Studio Code <https://code.visualstudio.com/docs/languages/python>`__

--- a/intro/intro.rst
+++ b/intro/intro.rst
@@ -347,7 +347,7 @@ As you move forward, it will be important to not only work interactively,
 but also to create and reuse Python files. For this, a powerful code editor
 will get you far. Here are several good easy-to-use editors:
 
-  * `Spyder <https://pythonhosted.org/spyder/>`_: integrates an IPython
+  * `Spyder <https://www.spyder-ide.org/>`_: integrates an IPython
     console, a debugger, a profiler...
   * `PyCharm <https://www.jetbrains.com/pycharm>`_: integrates an IPython
     console, notebooks, a debugger... (freely available,

--- a/intro/language/basic_types.rst
+++ b/intro/language/basic_types.rst
@@ -335,9 +335,8 @@ Slicing::
 
 .. tip::
    
-    Accents and special characters can also be handled in Unicode strings
-    (see
-    https://docs.python.org/tutorial/introduction.html#unicode-strings).
+    Accents and special characters can also be handled as in Python 3
+    strings consist of Unicode characters.
 
 
 A string is an **immutable object** and it is not possible to modify its

--- a/intro/language/basic_types.rst
+++ b/intro/language/basic_types.rst
@@ -367,7 +367,7 @@ contents. One may however create new strings from the original one.
     Python offers advanced possibilities for manipulating strings,
     looking for patterns or formatting. The interested reader is referred to
     https://docs.python.org/library/stdtypes.html#string-methods and
-    https://docs.python.org/library/string.html#new-string-formatting
+    https://docs.python.org/3/library/string.html#format-string-syntax
 
 String formatting::
 

--- a/intro/matplotlib/index.rst
+++ b/intro/matplotlib/index.rst
@@ -222,7 +222,7 @@ Changing colors and line widths
 .. hint:: Documentation
 
    * `Controlling line properties <http://matplotlib.org/users/pyplot_tutorial.html#controlling-line-properties>`_
-   * `Line API <http://matplotlib.org/api/artist_api.html#matplotlib.lines.Line2D>`_
+   * `Line API <https://matplotlib.org/api/_as_gen/matplotlib.lines.Line2D.html>`_
 
 .. tip::
 

--- a/intro/matplotlib/index.rst
+++ b/intro/matplotlib/index.rst
@@ -353,7 +353,7 @@ Moving spines
 
 .. hint:: Documentation
 
-   * `Spines <http://matplotlib.org/api/spines_api.html#matplotlib.spines>`_
+   * `Spines <https://matplotlib.org/api/spines_api.html>`_
    * `Axis container <http://matplotlib.org/users/artists.html#axis-container>`_
    * `Transformations tutorial <http://matplotlib.org/users/transforms_tutorial.html>`_
 
@@ -476,7 +476,7 @@ Devil is in the details
 .. hint:: Documentation
 
    * `Artists <http://matplotlib.org/api/artist_api.html>`_
-   * `BBox <http://matplotlib.org/api/artist_api.html#matplotlib.text.Text.set_bbox>`_
+   * `BBox <https://matplotlib.org/api/text_api.html#matplotlib.text.Text.set_bbox>`_
 
 .. tip::
 

--- a/intro/matplotlib/index.rst
+++ b/intro/matplotlib/index.rst
@@ -316,8 +316,8 @@ Setting tick labels
    * `Working with text <http://matplotlib.org/users/index_text.html>`_
    * `xticks() command <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.xticks>`_
    * `yticks() command <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.yticks>`_
-   * `set_xticklabels() <http://matplotlib.org/api/axes_api.html?#matplotlib.axes.Axes.set_xticklabels>`_
-   * `set_yticklabels() <http://matplotlib.org/api/axes_api.html?#matplotlib.axes.Axes.set_yticklabels>`_
+   * `set_xticklabels() <https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.set_xticklabels.html>`_
+   * `set_yticklabels() <https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.set_yticklabels.html>`_
 
 
 .. tip::

--- a/packages/scikit-image/index.rst
+++ b/packages/scikit-image/index.rst
@@ -716,12 +716,12 @@ Example: detecting corners using Harris detector ::
     :align: center
 
 (this example is taken from the `plot_corner
-<http://scikit-image.org/docs/stable/auto_examples/plot_corner.html>`_
+<http://scikit-image.org/docs/stable/auto_examples/features_detection/plot_corner.html>`_
 example in scikit-image)
 
 Points of interest such as corners can then be used to match objects in
 different images, as described in the `plot_matching 
-<http://scikit-image.org/docs/stable/auto_examples/plot_matching.html>`_
+<http://scikit-image.org/docs/stable/auto_examples/transform/plot_matching.html>`_
 example of scikit-image.
 
 Full code examples

--- a/packages/scikit-learn/examples/plot_eigenfaces.py
+++ b/packages/scikit-learn/examples/plot_eigenfaces.py
@@ -39,8 +39,8 @@ for i in range(15):
 #    gathering a sufficient amount of training data for the algorithm to work.
 #    Fortunately, this piece is common enough that it has been done. One good
 #    resource is
-#    `OpenCV <http://opencv.willowgarage.com/wiki/FaceRecognition>`__, the
-#    *Open Computer Vision Library*.
+#    `OpenCV <https://docs.opencv.org/2.4/modules/contrib/doc/facerec/facerec_tutorial.html>`__,
+#    the *Open Computer Vision Library*.
 #
 # We'll perform a Support Vector classification of the images. We'll do a
 # typical train-test split on the images:

--- a/packages/statistics/index.rst
+++ b/packages/statistics/index.rst
@@ -29,7 +29,7 @@ Statistics in Python
    * `Seaborn <http://seaborn.pydata.org>`__
 
    To install Python and these dependencies, we recommend that you
-   download `Anaconda Python <http://continuum.io/downloads>`_ or
+   download `Anaconda Python <https://www.anaconda.com/distribution/>`_ or
    `Enthought Canopy <https://store.enthought.com/>`_, or preferably use
    the package manager if you are under Ubuntu or other linux.
 

--- a/packages/traits/index.rst
+++ b/packages/traits/index.rst
@@ -28,7 +28,7 @@ The Traits project allows you to simply add validation, initialization, delegati
       `PyQt <https://riverbankcomputing.com/software/pyqt/intro>`_ or
       `PySide <https://pyside.github.io/docs/pyside/>`_
     * Numpy and Scipy
-    * `Enthought Tool Suite <http://code.enthought.com/projects>`_
+    * `Enthought Tool Suite <http://code.enthought.com/ets>`_
     * All required software can be obtained by installing the `EPD Free
       <https://store.enthought.com/>`_
 

--- a/packages/traits/index.rst
+++ b/packages/traits/index.rst
@@ -28,7 +28,7 @@ The Traits project allows you to simply add validation, initialization, delegati
       `PyQt <https://riverbankcomputing.com/software/pyqt/intro>`_ or
       `PySide <https://pyside.github.io/docs/pyside/>`_
     * Numpy and Scipy
-    * `Enthought Tool Suite <http://code.enthought.com/ets>`_
+    * `Enthought Tool Suite <http://docs.enthought.com/ets>`_
     * All required software can be obtained by installing the `EPD Free
       <https://store.enthought.com/>`_
 


### PR DESCRIPTION
`make linkcheck` listed 26 links as broken. In some cases, where the commit message explains my reasoning, it might be worth checking my replacement. There remain four broken links where I was not completely sure what to do:

* http://www.euroscipy.org/talk/882: The archive is presently not working but there are chances that this content might be reactivated.
* http://scipy.org/Developer_Zone/UG_Toc: Here, I was not quite sure what the original intention was.
* http://www.plope.com/Members/chrism/flymake-mode: see #452 for more details
* http://winpdb.org/: see #453 for more details