### PR TITLE
replace image i/o from scipy.misc by imageio

### DIFF
--- a/advanced/image_processing/examples/plot_face.py
+++ b/advanced/image_processing/examples/plot_face.py
@@ -6,8 +6,9 @@ Small example to plot a racoon face.
 """
 
 from scipy import misc
+import imageio
 f = misc.face()
-misc.imsave('face.png', f) # uses the Image module (PIL)
+imageio.imsave('face.png', f) # uses the Image module (PIL)
 
 import matplotlib.pyplot as plt
 plt.imshow(f)

--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -84,12 +84,13 @@ Writing an array to a file:
 Creating a numpy array from an image file::
 
     >>> from scipy import misc
+    >>> import imageio
     >>> face = misc.face()
-    >>> misc.imsave('face.png', face) # First we need to create the PNG file
+    >>> imageio.imsave('face.png', face) # First we need to create the PNG file
     
-    >>> face = misc.imread('face.png')
+    >>> face = imageio.imread('face.png')
     >>> type(face)      # doctest: +ELLIPSIS
-    <... 'numpy.ndarray'>
+    <class 'imageio.core.util.Array'>
     >>> face.shape, face.dtype
     ((768, 1024, 3), dtype('uint8'))
 
@@ -116,7 +117,7 @@ Working on a list of image files ::
 
     >>> for i in range(10):
     ...     im = np.random.randint(0, 256, 10000).reshape((100, 100))
-    ...     misc.imsave('random_%02d.png' % i, im)
+    ...     imageio.imsave('random_%02d.png' % i, im)
     >>> from glob import glob
     >>> filelist = glob('random*.png')
     >>> filelist.sort()

--- a/intro/numpy/advanced_operations.rst
+++ b/intro/numpy/advanced_operations.rst
@@ -160,8 +160,8 @@ This saved only one channel (of RGB)::
 
 Other libraries::
 
-    >>> from scipy.misc import imsave
-    >>> imsave('tiny_elephant.png', img[::6,::6])
+    >>> import imageio
+    >>> imageio.imsave('tiny_elephant.png', img[::6,::6])
     >>> plt.imshow(plt.imread('tiny_elephant.png'), interpolation='nearest')  # doctest: +ELLIPSIS
     <matplotlib.image.AxesImage object at ...>
 

--- a/intro/scipy.rst
+++ b/intro/scipy.rst
@@ -117,9 +117,9 @@ File input/output: :mod:`scipy.io`
 
 **Image files**: Reading images::
 
-    >>> from scipy import misc
-    >>> misc.imread('fname.png')    # doctest: +ELLIPSIS
-    array(...)
+    >>> import imageio
+    >>> imageio.imread('fname.png')    # doctest: +ELLIPSIS
+    Array(...)
     >>> # Matplotlib also has a similar function
     >>> import matplotlib.pyplot as plt
     >>> plt.imread('fname.png')    # doctest: +ELLIPSIS

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pytest>=5.1
 sphinx>=1.7,<1.8
 coverage==4.4.2
 pillow
+imageio>=2.8
 pip
 # For conda, pip installable
 sphinx-gallery==0.2.0


### PR DESCRIPTION
The SciPy routines are deprecated. imageio is the recommended successor.

Fix #385 