### PR TITLE
suppress warnings for mandelbrot example

### DIFF
--- a/intro/numpy/examples/plot_mandelbrot.py
+++ b/intro/numpy/examples/plot_mandelbrot.py
@@ -19,10 +19,14 @@ def compute_mandelbrot(N_max, some_threshold, nx, ny):
     # Mandelbrot iteration
 
     z = c
-    for j in range(N_max):
-        z = z**2 + c
 
-    mandelbrot_set = (abs(z) < some_threshold)
+    # The code below overflows in many region of the x-y grid, suppress
+    # warnings temporarily
+    with np.warnings.catch_warnings():
+        np.warnings.simplefilter("ignore")
+        for j in range(N_max):
+            z = z**2 + c
+        mandelbrot_set = (abs(z) < some_threshold)
 
     return mandelbrot_set
 

--- a/intro/numpy/examples/plot_mandelbrot.py
+++ b/intro/numpy/examples/plot_mandelbrot.py
@@ -20,7 +20,7 @@ def compute_mandelbrot(N_max, some_threshold, nx, ny):
 
     z = c
 
-    # The code below overflows in many region of the x-y grid, suppress
+    # The code below overflows in many regions of the x-y grid, suppress
     # warnings temporarily
     with np.warnings.catch_warnings():
         np.warnings.simplefilter("ignore")


### PR DESCRIPTION
the code applies the iteration for all array elements, some of which are
expected to overflow.

fix #480