### PR TITLE
Update functions.rst

### DIFF
--- a/intro/language/functions.rst
+++ b/intro/language/functions.rst
@@ -289,7 +289,7 @@ Special forms of parameters:
 
     In [36]: variable_args('one', 'two', x=1, y=2, z=3)
     args is ('one', 'two')
-    kwargs is {'y': 2, 'x': 1, 'z': 3}
+    kwargs is {'x': 1, 'y': 2, 'z': 3}
 
 
 Docstrings
@@ -348,7 +348,7 @@ Functions are first-class objects, which means they can be:
 
     In [39]: va('three', x=1, y=2)
     args is ('three',)
-    kwargs is {'y': 2, 'x': 1}
+    kwargs is {'x': 1, 'y': 2}
 
 
 Methods


### PR DESCRIPTION
Changes made:
1. Line 292 - From Python 3.6 onwards, the order of the keyword arguments in the dictionary returned preserves the order of the keyword arguments as they were input in the function call (as recommended in https://www.python.org/dev/peps/pep-0468/).  The output on Line 292 hence is edited to reflect this.
2. Line 351 - Same as above.