### PR TITLE
Update `.. warning` on NumPy in-place operations with views

### DIFF
--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -562,6 +562,18 @@ C and Fortran order
    - the results are different when interpreted as 2 of int16
    - ``.copy()`` creates new arrays in the C order (by default)
 
+.. note:: **In-place operations with views**
+
+    Prior to NumPy version 1.13, in-place operations with views could result in
+    **incorrect** results for large arrays.
+    Since :doc:`version 1.13 <numpy:release/1.13.0-notes>`,
+    NumPy includes checks for *memory overlap* to
+    guarantee that results are consistent with the non in-place version
+    (e.g. ``a = a + a.T`` produces the same result as ``a += a.T``).
+    Note however that this may result in the data being copied (as if using
+    ``a += a.T.copy()``), ultimately resulting in more memory being used than
+    might otherwise be expected for in-place operations!
+
 
 Slicing with integers
 .......................

--- a/intro/numpy/operations.rst
+++ b/intro/numpy/operations.rst
@@ -170,15 +170,22 @@ Other operations
            [1.,  1.,  0.]])
 
 
-.. warning:: **The transposition is a view**
+.. warning:: **In-place operations with views**
 
-    As a result, the following code **is wrong** and will **not make a
-    matrix symmetric**::
+    The transpose returns a view of the original array. What happens when
+    attempting to perform an *in-place* operation on a *view*? For example::
 
         >>> a += a.T
 
-    It will work for small arrays (because of buffering) but fail for
-    large one, in unpredictable ways.
+    Prior to NumPy version 1.13, in-place operations with views could result in
+    **incorrect** results for large arrays.
+    Since :doc:`version 1.13 <numpy:release/1.13.0-notes>`,
+    NumPy includes checks for *memory overlap* to 
+    guarantee that results for cases like the above are consistent with the
+    non in-place version (e.g. ``a = a + a.T``).
+    Note however that this may require the data to be copied, 
+    resulting in more memory being used than might otherwise be expected for
+    in-place operations!
 
 .. note:: **Linear algebra**
 

--- a/intro/numpy/operations.rst
+++ b/intro/numpy/operations.rst
@@ -183,9 +183,9 @@ Other operations
     NumPy includes checks for *memory overlap* to 
     guarantee that results for cases like the above are consistent with the
     non in-place version (e.g. ``a = a + a.T``).
-    Note however that this may require the data to be copied, 
-    resulting in more memory being used than might otherwise be expected for
-    in-place operations!
+    Note however that this may result in the data being copied (as if using
+    ``a += a.T.copy()``), ultimately resulting in more memory being used than
+    might otherwise be expected for in-place operations!
 
 .. note:: **Linear algebra**
 

--- a/intro/numpy/operations.rst
+++ b/intro/numpy/operations.rst
@@ -170,22 +170,20 @@ Other operations
            [1.,  1.,  0.]])
 
 
-.. warning:: **In-place operations with views**
+.. note:: **The transposition is a view**
 
-    The transpose returns a view of the original array. What happens when
-    attempting to perform an *in-place* operation on a *view*? For example::
+    The transpose returns a *view* of the original array::
 
-        >>> a += a.T
-
-    Prior to NumPy version 1.13, in-place operations with views could result in
-    **incorrect** results for large arrays.
-    Since :doc:`version 1.13 <numpy:release/1.13.0-notes>`,
-    NumPy includes checks for *memory overlap* to 
-    guarantee that results for cases like the above are consistent with the
-    non in-place version (e.g. ``a = a + a.T``).
-    Note however that this may result in the data being copied (as if using
-    ``a += a.T.copy()``), ultimately resulting in more memory being used than
-    might otherwise be expected for in-place operations!
+        >>> a = np.arange(9).reshape(3, 3)
+        >>> a.T[0, 2] = 999
+        >>> a.T
+        array([[  0,   3, 999],
+               [  1,   4,   7],
+               [  2,   5,   8]])
+        >>> a
+        array([[  0,   1,   2],
+               [  3,   4,   5],
+               [999,   7,   8]])
 
 .. note:: **Linear algebra**
 


### PR DESCRIPTION
I had noticed that a warning box in the numpy operations section illustrated behavior from numpy versions prior to 1.13: see [these release notes](https://numpy.org/devdocs/release/1.13.0-notes.html#ufunc-behavior-for-overlapping-inputs) for details (thanks to @seberg for pointing me to these specific docs). 

In this PR, I updated the text to more accurately reflect the behavior of NumPy since version 1.13. The new text might go into too much detail to really fit in this section, so other possible alternatives might be:
 1. Remove the warning box altogether
 2. Replace the `.. warning` with a `.. note` (or other "informational" directive) that indicates that the transpose returns a view, without the additional `a += a.T` example.