### PR TITLE
DOC: Update links to numpy.org doc site.

### DIFF
--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -147,7 +147,7 @@ array of ints::
 The ``owndata`` and ``writeable`` flags indicate status of the memory
 block.
 
-.. seealso::: `array interface <http://docs.scipy.org/doc/numpy/reference/arrays.interface.html>`_
+.. seealso::: `array interface <http://numpy.org/doc/stable/reference/arrays.interface.html>`_
 
 Data types
 ----------
@@ -333,7 +333,7 @@ Casting
 .. note::
 
    Exact rules: see `numpy documentation
-   <http://docs.scipy.org/doc/numpy/reference/ufuncs.html#casting-rules>`_
+   <http://numpy.org/doc/stable/reference/ufuncs.html#casting-rules>`_
 
 
 Re-interpretation / viewing
@@ -1254,7 +1254,7 @@ Array interface protocol
 .. seealso::
 
    Documentation:
-   http://docs.scipy.org/doc/numpy/reference/arrays.interface.html
+   http://numpy.org/doc/stable/reference/arrays.interface.html
 
 ::
 

--- a/advanced/interfacing_with_c/interfacing_with_c.rst
+++ b/advanced/interfacing_with_c/interfacing_with_c.rst
@@ -207,16 +207,16 @@ Numpy Support
 
 Analog to the Python-C-API, Numpy, which is itself implemented as a
 C-extension, comes with the `Numpy-C-API
-<http://docs.scipy.org/doc/numpy/reference/c-api.html>`_. This API can be used
+<http://numpy.org/doc/stable/reference/c-api>`_. This API can be used
 to create and manipulate Numpy arrays from C, when writing a custom
 C-extension. See also: :ref:`advanced_numpy`.
 
 .. note::
 
     If you do ever need to use the Numpy C-API refer to the documentation about
-    `Arrays <http://docs.scipy.org/doc/numpy/reference/c-api.array.html>`_ and
+    `Arrays <http://numpy.org/doc/stable/reference/c-api/array.html>`_ and
     `Iterators
-    <http://docs.scipy.org/doc/numpy/reference/c-api.iterator.html>`_.
+    <http://numpy.org/doc/stable/reference/c-api/iterator.html>`_.
 
 The following example shows how to pass Numpy arrays as arguments to functions
 and how to iterate over Numpy arrays using the (old) Numpy-C-API. It simply
@@ -342,8 +342,8 @@ and there are functions to convert from C arrays to Numpy arrays and back.
 
 For more information, consult the corresponding section in the `Numpy Cookbook
 <http://www.scipy.org/Cookbook/Ctypes>`_ and the API documentation for
-`numpy.ndarray.ctypes <http://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.ctypes.html>`_
-and `numpy.ctypeslib <http://docs.scipy.org/doc/numpy/reference/routines.ctypeslib.html>`_.
+`numpy.ndarray.ctypes <http://numpy.org/doc/stable/reference/generated/numpy.ndarray.ctypes.html>`_
+and `numpy.ctypeslib <http://numpy.org/doc/stable/reference/routines.ctypeslib.html>`_.
 
 For the following example, let's consider a C function in a library that takes
 an input and an output array, computes the cosine of the input array and
@@ -545,7 +545,7 @@ Numpy Support
 -------------
 
 Numpy provides `support for SWIG
-<http://docs.scipy.org/doc/numpy/reference/swig.html>`_ with the ``numpy.i``
+<http://numpy.org/doc/stable/reference/swig.html>`_ with the ``numpy.i``
 file. This interface file defines various so-called *typemaps* which support
 conversion between Numpy arrays and C-Arrays. In the following example we will
 take a quick look at how such typemaps work in practice.
@@ -873,7 +873,7 @@ Python-C-API
 #. Modify the example such that the function only takes a single input array
    and modifies this in place.
 #. Try to fix the example to use the new `Numpy iterator protocol
-   <http://docs.scipy.org/doc/numpy/reference/c-api.iterator.html>`_. If you
+   <http://numpy.org/doc/stable/reference/c-api/iterator.html>`_. If you
    manage to obtain a working solution, please submit a pull-request on github.
 #. You may have noticed, that the Numpy-C-API example is the only Numpy example
    that does not wrap ``cos_doubles`` but instead applies the ``cos`` function

--- a/conf.py
+++ b/conf.py
@@ -348,7 +348,7 @@ _python_doc_base = 'https://docs.python.org/{.major}'.format(sys.version_info)
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': (_python_doc_base, None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'mayavi': ('http://docs.enthought.com/mayavi/mayavi', None),

--- a/intro/help/help.rst
+++ b/intro/help/help.rst
@@ -33,7 +33,7 @@ just to display help and docstrings...
 * Numpy's and Scipy's documentations can be browsed online on
   http://docs.scipy.org/doc. The ``search`` button is quite useful inside
   the reference documentation of the two packages
-  (http://docs.scipy.org/doc/numpy/reference/ and
+  (http://numpy.org/doc/stable/reference/ and
   http://docs.scipy.org/doc/scipy/reference/). 
 
   Tutorials on various topics as well as the complete API with all
@@ -43,11 +43,11 @@ just to display help and docstrings...
 
   .. image:: docwiki.png
      :align: right
-     :target: http://docs.scipy.org/doc/numpy/
+     :target: http://numpy.org/doc/stable/
      :width: 45%
 
 * Numpy's and Scipy's documentation is enriched and updated on a regular
-  basis by users on a wiki http://docs.scipy.org/doc/numpy/. As a result,
+  basis by users on a wiki http://numpy.org/doc/stable/. As a result,
   some docstrings are clearer or more detailed on the wiki, and you may
   want to read directly the documentation on the wiki instead of the
   official documentation website. Note that anyone can create an account on

--- a/intro/numpy/advanced_operations.rst
+++ b/intro/numpy/advanced_operations.rst
@@ -47,7 +47,7 @@ For example, :math:`3x^2 + 2x - 1`::
     :target: auto_examples/plot_polyfit.html
     :align: center
 
-See http://docs.scipy.org/doc/numpy/reference/routines.polynomials.poly1d.html
+See http://numpy.org/doc/stable/reference/routines.polynomials.poly1d.html
 for more.
 
 More polynomials (with more bases)

--- a/intro/numpy/elaborate_arrays.rst
+++ b/intro/numpy/elaborate_arrays.rst
@@ -205,8 +205,8 @@ Fancy indexing works, as usual::
           dtype=[('sensor_code', 'S4'), ('position', '<f8'), ('value', '<f8')])
 
 .. note:: There are a bunch of other syntaxes for constructing structured
-   arrays, see `here <http://docs.scipy.org/doc/numpy/user/basics.rec.html>`__
-   and `here <http://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html#specifying-and-constructing-data-types>`__.
+   arrays, see `here <http://numpy.org/doc/stable/user/basics.rec.html>`__
+   and `here <http://numpy.org/doc/stable/reference/arrays.dtypes.html#specifying-and-constructing-data-types>`__.
 
 
 :class:`maskedarray`: dealing with (propagation of) missing data


### PR DESCRIPTION
Updates links from old URL at scipy.org to the current URL hosting numpy documentation.

Also fixes a few broken links to NumPy C-API docs.