### PR TITLE
Minor updates to the articles on NumPy

### DIFF
--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -500,6 +500,12 @@ Main point
 C and Fortran order
 .....................
 
+.. note::
+   The Python built-in :py:class:`bytes` returns bytes in C-order by default
+   which can cause confusion when trying to inspect memory layout. We use
+   :meth:`numpy.ndarray.tobytes` with ``order=A`` instead, which preserves
+   the C or F ordering of the bytes in memory.
+
 ::
 
     >>> x = np.array([[1, 2, 3], 

--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -474,8 +474,8 @@ Main point
   >>> x = np.array([[1, 2, 3], 
   ...	            [4, 5, 6], 
   ...	            [7, 8, 9]], dtype=np.int8)
-  >>> str(x.data)  # doctest: +SKIP
-  '\x01\x02\x03\x04\x05\x06\x07\x08\t'
+  >>> bytes(x.data)  # doctest: +SKIP
+  b'\x01\x02\x03\x04\x05\x06\x07\x08\t'
 
   At which byte in ``x.data`` does the item ``x[1, 2]`` begin?
 
@@ -506,8 +506,8 @@ C and Fortran order
     ...               [4, 5, 6]], dtype=np.int16, order='C')
     >>> x.strides
     (6, 2)
-    >>> str(x.data)  # doctest: +SKIP
-    '\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00'
+    >>> bytes(x.data)  # doctest: +SKIP
+    b'\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00'
 
 * Need to jump 6 bytes to find the next row
 * Need to jump 2 bytes to find the next column 
@@ -517,8 +517,8 @@ C and Fortran order
     >>> y = np.array(x, order='F')
     >>> y.strides
     (2, 4)
-    >>> str(y.data)  # doctest: +SKIP
-    '\x01\x00\x04\x00\x02\x00\x05\x00\x03\x00\x06\x00'
+    >>> bytes(y.data)  # doctest: +SKIP
+    b'\x01\x00\x04\x00\x02\x00\x05\x00\x03\x00\x06\x00'
 
 * Need to jump 2 bytes to find the next row
 * Need to jump 4 bytes to find the next column 
@@ -554,10 +554,10 @@ C and Fortran order
    >>> y.strides
    (1, 2)
 
-   >>> str(x.data)  # doctest: +SKIP
-   '\x01\x02\x03\x04'
-   >>> str(y.data)  # doctest: +SKIP
-   '\x01\x03\x02\x04'
+   >>> bytes(x.data)  # doctest: +SKIP
+   b'\x01\x02\x03\x04'
+   >>> bytes(y.data)  # doctest: +SKIP
+   b'\x01\x03\x02\x04'
 
    - the results are different when interpreted as 2 of int16
    - ``.copy()`` creates new arrays in the C order (by default)
@@ -607,8 +607,8 @@ strides::
 
 So far, so good. However::
 
-    >>> str(a.data)  # doctest: +SKIP
-    '\x00\x01\x02\x03\x04\x05'
+    >>> bytes(a.data)  # doctest: +SKIP
+    b'\x00\x01\x02\x03\x04\x05'
     >>> b
     array([[0, 2, 4],
            [1, 3, 5]], dtype=int8)

--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -474,7 +474,7 @@ Main point
   >>> x = np.array([[1, 2, 3], 
   ...	            [4, 5, 6], 
   ...	            [7, 8, 9]], dtype=np.int8)
-  >>> bytes(x.data)  # doctest: +SKIP
+  >>> x.tobytes('A')
   b'\x01\x02\x03\x04\x05\x06\x07\x08\t'
 
   At which byte in ``x.data`` does the item ``x[1, 2]`` begin?
@@ -506,7 +506,7 @@ C and Fortran order
     ...               [4, 5, 6]], dtype=np.int16, order='C')
     >>> x.strides
     (6, 2)
-    >>> bytes(x.data)  # doctest: +SKIP
+    >>> x.tobytes('A')
     b'\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00'
 
 * Need to jump 6 bytes to find the next row
@@ -517,7 +517,7 @@ C and Fortran order
     >>> y = np.array(x, order='F')
     >>> y.strides
     (2, 4)
-    >>> bytes(y.data)  # doctest: +SKIP
+    >>> y.tobytes('A')
     b'\x01\x00\x04\x00\x02\x00\x05\x00\x03\x00\x06\x00'
 
 * Need to jump 2 bytes to find the next row
@@ -554,9 +554,9 @@ C and Fortran order
    >>> y.strides
    (1, 2)
 
-   >>> bytes(x.data)  # doctest: +SKIP
+   >>> x.tobytes('A')
    b'\x01\x02\x03\x04'
-   >>> bytes(y.data)  # doctest: +SKIP
+   >>> y.tobytes('A')
    b'\x01\x03\x02\x04'
 
    - the results are different when interpreted as 2 of int16
@@ -607,7 +607,7 @@ strides::
 
 So far, so good. However::
 
-    >>> bytes(a.data)  # doctest: +SKIP
+    >>> bytes(a.data)
     b'\x00\x01\x02\x03\x04\x05'
     >>> b
     array([[0, 2, 4],

--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -91,7 +91,7 @@ operations.
 NumPy Reference documentation
 ..............................
 
-- On the web: http://docs.scipy.org/
+- On the web: https://numpy.org/doc/
 
 - Interactive help:
 

--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -508,7 +508,7 @@ The usual python idiom for reversing a sequence is supported:
    >>> a[::-1]
    array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
 
-For multidimensional arrays, indexes are tuples of integers:
+For multidimensional arrays, indices are tuples of integers:
 
 .. sourcecode:: pycon
 

--- a/intro/numpy/elaborate_arrays.rst
+++ b/intro/numpy/elaborate_arrays.rst
@@ -136,9 +136,9 @@ Complex floating-point numbers:
 
      .. sourcecode:: ipython
 
-        In [1]: a = np.zeros((1e6,), dtype=np.float64)
+        In [1]: a = np.zeros((int(1e6),), dtype=np.float64)
 
-        In [2]: b = np.zeros((1e6,), dtype=np.float32)
+        In [2]: b = np.zeros((int(1e6),), dtype=np.float32)
 
         In [3]: %timeit a*a
         1000 loops, best of 3: 1.78 ms per loop


### PR DESCRIPTION
First off, thanks so much to the authors/contributors of the SLN - they are a great resource for learning & illustrating the features of the scientific Python ecosystem!

A few minor changes from a recent re-read of the NumPy articles (intro & advanced):

 * A wording suggestion (indexes->indices for consistency with the rest of the document)
 * Convert instances of `str(arr.data)` to `bytes(arr.data)` when used to illustrate the contents of the `data` attribute of arrays
 * Explicitly convert a couple instances of floats in scientific notation -> int so they are valid input to `np.zeros`