### PR TITLE
link to PyMC3 instead of PyMC2

### DIFF
--- a/packages/statistics/index.rst
+++ b/packages/statistics/index.rst
@@ -40,7 +40,7 @@ Statistics in Python
  * **Bayesian statistics in Python**:
    This chapter does not cover tools for Bayesian statistics. Of
    particular interest for Bayesian modelling is `PyMC
-   <http://pymc-devs.github.io/pymc>`_, which implements a probabilistic
+   <https://docs.pymc.io/>`_, which implements a probabilistic
    programming language in Python.
 
  * **Read a statistics book**:


### PR DESCRIPTION
Hi,

I updated the link to point to the current PyMC homepage.

Thank you for your great work on the lecture notes!