### PR TITLE
docs: fix simple typo, itegrates -> integrates

### DIFF
--- a/intro/intro.rst
+++ b/intro/intro.rst
@@ -353,7 +353,7 @@ will get you far. Here are several good easy-to-use editors:
     console, notebooks, a debugger... (freely available,
     but commercial)
   * `Visual Studio Code <https://code.visualstudio.com/docs/languages/python>`_:
-    itegrates a Python console, notebooks, a debugger, ...
+    integrates a Python console, notebooks, a debugger, ...
   * `Atom <https://atom.io>`_
 
 Some of these are shipped by the various scientific Python distributions,


### PR DESCRIPTION
There is a small typo in intro/intro.rst.

Should read `integrates` rather than `itegrates`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md