### PR TITLE
Fix inner plot in fftpack example

### DIFF
--- a/intro/scipy/examples/plot_fftpack.py
+++ b/intro/scipy/examples/plot_fftpack.py
@@ -65,7 +65,7 @@ np.allclose(peak_freq, 1./period)
 # An inner plot to show the peak frequency
 axes = plt.axes([0.55, 0.3, 0.3, 0.5])
 plt.title('Peak frequency')
-plt.plot(freqs[:8], power[:8])
+plt.plot(freqs[:8], power[pos_mask][:8])
 plt.setp(axes, yticks=[])
 
 # scipy.signal.find_peaks_cwt can also be used for more advanced


### PR DESCRIPTION
The inner plot incorrectly has the peak at 0.25 where the peak frequency should be at 0.2.

Explanation of fix: 
The x axis plots the `freqs` variable after removing the non-positive values while the y axis plots `power` without removing the non-positive values and that's what causing the error. The fist just removes the non-positive values in the y axis as well.