### PR TITLE
Use conda forge

### DIFF
--- a/build_tools/install.sh
+++ b/build_tools/install.sh
@@ -40,6 +40,8 @@ create_new_conda_env() {
     bash miniconda.sh -b -p $HOME/miniconda
     export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
+    conda config --add channels conda-forge
+    conda config --set channel_priority strict
 
     # Create a conda environment
     python build_tools/requirements_to_environment.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pytest>=5.1
 sphinx>=1.7,<1.8
 coverage==4.4.2
 pillow
-imageio>=2.8
+imageio==2.13.5
 pip
 # For conda, pip installable
 sphinx-gallery==0.2.0


### PR DESCRIPTION
Use conda-forge as it has better and more up-to-date packages. Conda-forge also pulled in a version of imageio that requires Python 3.7. I pinned imagio to the last version that supported Python 3.6. I will deal with the Python 3.6 in a separate PR. I am trying to get a few minor things cleaned up in small PRs so that it will be easier to review a bgger PR later.