### PR TITLE
Fix path to circleci artifact

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -10,5 +10,5 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-path: 0/doc/build/html/index.html
+          artifact-path: 0/build/html/index.html
           circleci-jobs: build


### PR DESCRIPTION
I had the path wrong; but the redirect works with this change.