### PR TITLE
Use Python 3.8+ and bump dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
 
     steps:
       - checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -45,7 +45,7 @@ This section covers:
    :depth: 2
 
 .. tip::
-   
+
    In this section, numpy will be imported as follows::
 
     >>> import numpy as np
@@ -70,23 +70,23 @@ It's...
 .. code-block:: c
 
    typedef struct PyArrayObject {
-	   PyObject_HEAD
+           PyObject_HEAD
 
            /* Block of memory */
-	   char *data;
+           char *data;
 
            /* Data type descriptor */
-	   PyArray_Descr *descr;
+           PyArray_Descr *descr;
 
            /* Indexing scheme */
-	   int nd;
-	   npy_intp *dimensions;
-	   npy_intp *strides;
+           int nd;
+           npy_intp *dimensions;
+           npy_intp *strides;
 
            /* Other stuff */
-	   PyObject *base;
-	   int flags;
-	   PyObject *weakreflist;
+           PyObject *base;
+           int flags;
+           PyObject *weakreflist;
    } PyArrayObject;
 
 
@@ -265,14 +265,14 @@ Let's try accessing the sub-array:
 
 >>> wav_header['data_id']  # doctest: +SKIP
 array([[['d', 'a'],
-        ['t', 'a']]], 
+        ['t', 'a']]],
       dtype='|S1')
 >>> wav_header.shape
 (1,)
 >>> wav_header['data_id'].shape
 (1, 2, 2)
 
-When accessing sub-arrays, the dimensions get added to the end! 
+When accessing sub-arrays, the dimensions get added to the end!
 
 .. note::
 
@@ -383,7 +383,6 @@ Re-interpretation / viewing
    ``0x01``    ``0x02``    ``0x03``    ``0x04``
   ==========  ==========  ==========  ==========
 
-
 .. note::
 
    - ``.view()`` makes *views*, does not copy (or alter) the memory block
@@ -426,9 +425,9 @@ without copying data? ::
        <a onclick="$('#hidden-item-0').toggle(100)">...</a>
        <div id="hidden-item-0" style="display: none;">
 
-    >>> y = x.view([('r', 'i1'), 
-    ...             ('g', 'i1'), 
-    ...             ('b', 'i1'), 
+    >>> y = x.view([('r', 'i1'),
+    ...             ('g', 'i1'),
+    ...             ('b', 'i1'),
     ...             ('a', 'i1')]
     ...              )[:, :, 0]
 
@@ -495,9 +494,9 @@ Main point
 
 **The question**::
 
-  >>> x = np.array([[1, 2, 3], 
-  ...	            [4, 5, 6], 
-  ...	            [7, 8, 9]], dtype=np.int8)
+  >>> x = np.array([[1, 2, 3],
+  ...               [4, 5, 6],
+  ...               [7, 8, 9]], dtype=np.int8)
   >>> x.tobytes('A')
   b'\x01\x02\x03\x04\x05\x06\x07\x08\t'
 
@@ -513,7 +512,7 @@ Main point
     >>> x.strides
     (3, 1)
     >>> byte_offset = 3*1 + 1*2   # to find x[1, 2]
-    >>> x.flat[byte_offset] 
+    >>> x.flat[byte_offset]
     6
     >>> x[1, 2]
     6
@@ -532,7 +531,7 @@ C and Fortran order
 
 ::
 
-    >>> x = np.array([[1, 2, 3], 
+    >>> x = np.array([[1, 2, 3],
     ...               [4, 5, 6]], dtype=np.int16, order='C')
     >>> x.strides
     (6, 2)
@@ -540,7 +539,7 @@ C and Fortran order
     b'\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00'
 
 * Need to jump 6 bytes to find the next row
-* Need to jump 2 bytes to find the next column 
+* Need to jump 2 bytes to find the next column
 
 ::
 
@@ -551,7 +550,7 @@ C and Fortran order
     b'\x01\x00\x04\x00\x02\x00\x05\x00\x03\x00\x06\x00'
 
 * Need to jump 2 bytes to find the next row
-* Need to jump 4 bytes to find the next column 
+* Need to jump 4 bytes to find the next column
 
 
 - Similarly to higher dimensions:
@@ -566,14 +565,14 @@ C and Fortran order
      \mathrm{strides} &= (s_1, s_2, ..., s_n)
      \\
      s_j^C &= d_{j+1} d_{j+2} ... d_{n} \times \mathrm{itemsize}
-     \\ 
+     \\
      s_j^F &= d_{1} d_{2} ... d_{j-1} \times \mathrm{itemsize}
 
 
 .. note::
 
    Now we can understand the behavior of ``.view()``:
-   
+
    >>> y = np.array([[1, 3], [2, 4]], dtype=np.uint8).transpose()
    >>> x = y.copy()
 
@@ -608,7 +607,7 @@ C and Fortran order
 Slicing with integers
 .......................
 
-- *Everything* can be represented by changing only ``shape``, ``strides``, 
+- *Everything* can be represented by changing only ``shape``, ``strides``,
   and possibly adjusting the ``data`` pointer!
 - Never makes copies of the data
 
@@ -676,8 +675,8 @@ as_strided(x, shape=None, strides=None)
 
 .. warning::
 
-   ``as_strided`` does **not** check that you stay inside the memory 
-   block bounds... 
+   ``as_strided`` does **not** check that you stay inside the memory
+   block bounds...
 
 >>> x = np.array([1, 2, 3, 4], dtype=np.int16)
 >>> as_strided(x, strides=(2*2, ), shape=(2, ))
@@ -803,7 +802,7 @@ More tricks: diagonals
 
       >>> as_strided(x[0, 1:], shape=(2, ), strides=((3+1)*x.itemsize, ))
       array([2, 6], dtype=int32)
-        
+
       >>> as_strided(x[1:, 0], shape=(2, ), strides=((3+1)*x.itemsize, ))
       array([4, 8], dtype=int32)
 
@@ -949,9 +948,9 @@ Parts of an Ufunc
 
        void ufunc_loop(void **args, int *dimensions, int *steps, void *data)
        {
-           /* 
+           /*
             * int8 output = elementwise_function(int8 input_1, int8 input_2)
-	    * 
+            *
             * This function must compute the ufunc for many values at once,
             * in the way shown below.
             */
@@ -961,7 +960,7 @@ Parts of an Ufunc
            int i;
 
            for (i = 0; i < dimensions[0]; ++i) {
-	       *output = elementwise_function(*input_1, *input_2);
+               *output = elementwise_function(*input_1, *input_2);
                input_1 += steps[0];
                input_2 += steps[1];
                output += steps[2];
@@ -981,16 +980,16 @@ Parts of an Ufunc
       PyObject *python_ufunc = PyUFunc_FromFuncAndData(
           ufunc_loop,
           NULL,
-          types, 
+          types,
           1, /* ntypes */
-          2, /* num_inputs */ 
+          2, /* num_inputs */
           1, /* num_outputs */
           identity_element,
-          name, 
-          docstring, 
+          name,
+          docstring,
           unused)
 
-   - A ufunc can also support multiple different input-output type 
+   - A ufunc can also support multiple different input-output type
      combinations.
 
 Making it easier
@@ -1086,12 +1085,12 @@ E.g. supporting both single- and double-precision versions
 
 .. sourcecode:: cython
 
-   cdef void mandel_single_point(double complex *z_in, 
+   cdef void mandel_single_point(double complex *z_in,
                                  double complex *c_in,
                                  double complex *z_out) nogil:
       ...
 
-   cdef void mandel_single_point_singleprec(float complex *z_in, 
+   cdef void mandel_single_point_singleprec(float complex *z_in,
                                             float complex *c_in,
                                             float complex *z_out) nogil:
       ...
@@ -1156,7 +1155,7 @@ Generalized ufuncs
         (m, n), (n, p) -> (m, p)
 
     * This is called the *"signature"* of the generalized ufunc
-    * The dimensions on which the g-ufunc acts, are *"core dimensions"* 
+    * The dimensions on which the g-ufunc acts, are *"core dimensions"*
 
 .. rubric:: Status in NumPy
 
@@ -1176,7 +1175,7 @@ Generalized ufuncs
     >>> import numpy.core.umath_tests as ut
     >>> ut.matrix_multiply.signature
     '(m,n),(n,p)->(m,p)'
-    
+
     >>> x = np.ones((10, 2, 4))
     >>> y = np.ones((10, 4, 5))
     >>> ut.matrix_multiply(x, y).shape
@@ -1197,31 +1196,31 @@ Matrix multiplication ``(m,n),(n,p) -> (m,p)``
 
     void gufunc_loop(void **args, int *dimensions, int *steps, void *data)
     {
-	char *input_1 = (char*)args[0];  /* these are as previously */
-	char *input_2 = (char*)args[1];   
-	char *output = (char*)args[2];   
+        char *input_1 = (char*)args[0];  /* these are as previously */
+        char *input_2 = (char*)args[1];
+        char *output = (char*)args[2];
 
-	int input_1_stride_m = steps[3];  /* strides for the core dimensions */
-	int input_1_stride_n = steps[4];  /* are added after the non-core */
-	int input_2_strides_n = steps[5]; /* steps */
-	int input_2_strides_p = steps[6];
-	int output_strides_n = steps[7];
-	int output_strides_p = steps[8];
+        int input_1_stride_m = steps[3];  /* strides for the core dimensions */
+        int input_1_stride_n = steps[4];  /* are added after the non-core */
+        int input_2_strides_n = steps[5]; /* steps */
+        int input_2_strides_p = steps[6];
+        int output_strides_n = steps[7];
+        int output_strides_p = steps[8];
 
-	int m = dimension[1]; /* core dimensions are added after */
-	int n = dimension[2]; /* the main dimension; order as in */
-	int p = dimension[3]; /* signature */
-    
-	int i;
+        int m = dimension[1]; /* core dimensions are added after */
+        int n = dimension[2]; /* the main dimension; order as in */
+        int p = dimension[3]; /* signature */
 
-	for (i = 0; i < dimensions[0]; ++i) {
-            matmul_for_strided_matrices(input_1, input_2, output, 
+        int i;
+
+        for (i = 0; i < dimensions[0]; ++i) {
+            matmul_for_strided_matrices(input_1, input_2, output,
                                         strides for each array...);
 
-	    input_1 += steps[0];
-	    input_2 += steps[1];
-	    output += steps[2];
-	}
+            input_1 += steps[0];
+            input_2 += steps[1];
+            output += steps[2];
+        }
     }
 
 
@@ -1255,7 +1254,7 @@ The old buffer protocol
 - Only 1-D buffers
 - No data type information
 - C-level interface; ``PyBufferProcs tp_as_buffer`` in the type object
-- But it's integrated into Python  (e.g. strings support it) 
+- But it's integrated into Python  (e.g. strings support it)
 
 Mini-exercise using `Pillow <https://python-pillow.github.io/>`_ (Python
 Imaging Library):
@@ -1320,7 +1319,7 @@ Array interface protocol
    >>> plt.imsave('data/test.png', data)
 
 
-:: 
+::
     >>> from PIL import Image
     >>> img = Image.open('data/test.png')
     >>> img.__array_interface__     # doctest: +SKIP
@@ -1346,10 +1345,10 @@ Array siblings: :class:`chararray`, :class:`maskedarray`, :class:`matrix`
 
 >>> x = np.array(['a', '  bbb', '  ccc']).view(np.chararray)
 >>> x.lstrip(' ')       # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-chararray(['a', 'bbb', 'ccc'], 
+chararray(['a', 'bbb', 'ccc'],
       dtype='...')
 >>> x.upper()       # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-chararray(['A', '  BBB', '  CCC'], 
+chararray(['A', '  BBB', '  CCC'],
       dtype='...')
 
 .. note::
@@ -1493,7 +1492,7 @@ The masked array package also contains domain-aware functions::
 >>> arr = np.array([('a', 1), ('b', 2)], dtype=[('x', 'S1'), ('y', int)])
 >>> arr2 = arr.view(np.recarray)
 >>> arr2.x       # doctest: +SKIP
-chararray(['a', 'b'], 
+chararray(['a', 'b'],
       dtype='|S1')
 >>> arr2.y
 array([1, 2])
@@ -1566,7 +1565,7 @@ Good bug report
 
     I'm trying to generate random permutations, using numpy.random.permutations
 
-    When calling numpy.random.permutation with non-integer arguments 
+    When calling numpy.random.permutation with non-integer arguments
     it fails with a cryptic error message::
 
         >>> np.random.permutation(12)
@@ -1629,7 +1628,7 @@ Contributing to documentation
 
        - But: **you can turn mail delivery off**
 
-       - "change your subscription options", at the bottom of 
+       - "change your subscription options", at the bottom of
 
          http://mail.python.org/mailman/listinfo/scipy-dev
 
@@ -1641,8 +1640,8 @@ Contributing to documentation
 
           I'd like to edit NumPy/Scipy docstrings. My account is XXXXX
 
-	  Cheers,
-	  N. N.
+          Cheers,
+          N. N.
 
     - Check the style guide:
 
@@ -1654,7 +1653,7 @@ Contributing to documentation
 
 2. Edit sources and send patches (as for bugs)
 
-3. Complain on the mailing list 
+3. Complain on the mailing list
 
 
 Contributing features
@@ -1665,7 +1664,7 @@ Contributing features
 How to help, in general
 -----------------------
 
-- Bug fixes always welcome! 
+- Bug fixes always welcome!
 
   - What irks you most
   - Browse the tracker
@@ -1688,4 +1687,3 @@ How to help, in general
 
   - ``numpy-discussion`` list
   - ``scipy-dev`` list
-

--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -142,7 +142,7 @@ array of ints::
       WRITEABLE : False
       ALIGNED : True
       WRITEBACKIFCOPY : False
-      UPDATEIFCOPY : False
+
 
 The ``owndata`` and ``writeable`` flags indicate status of the memory
 block.
@@ -309,7 +309,7 @@ Casting
 
 - Casting in general copies data::
 
-    >>> x = np.array([1, 2, 3, 4], dtype=np.float)
+    >>> x = np.array([1, 2, 3, 4], dtype=float)
     >>> x
     array([1.,  2.,  3.,  4.])
     >>> y = x.astype(np.int8)
@@ -453,7 +453,7 @@ without copying data? ::
           [1027]], dtype=int16)
    >>> 0x0201, 0x0403
    (513, 1027)
-   >>> y.view(np.int16)
+   >>> y.view(np.int16)  # doctest: +SKIP
    array([[ 769, 1026]], dtype=int16)
 
    - What happened?
@@ -601,7 +601,7 @@ Slicing with integers
     >>> y.__array_interface__['data'][0] - x.__array_interface__['data'][0]
     8
 
-    >>> x = np.zeros((10, 10, 10), dtype=np.float)
+    >>> x = np.zeros((10, 10, 10), dtype=float)
     >>> x.strides
     (800, 80, 8)
     >>> x[::2,::3,::4].strides
@@ -609,7 +609,7 @@ Slicing with integers
 
 - Similarly, transposes never make copies (it just swaps strides)::
 
-    >>> x = np.zeros((10, 10, 10), dtype=np.float)
+    >>> x = np.zeros((10, 10, 10), dtype=float)
     >>> x.strides
     (800, 80, 8)
     >>> x.T.strides
@@ -1413,8 +1413,8 @@ Domain-aware functions
 
 The masked array package also contains domain-aware functions::
 
-    >>> np.ma.log(np.array([1, 2, -1, -2, 3, -5]))
-    masked_array(data=[0.0, 0.6931471805599453, --, --, 1.0986122886681098, --],
+    >>> np.ma.log(np.array([1, 2, -1, -2, 3, -5]))  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    masked_array(data=[0.0, 0.693147180559..., --, --, 1.098612288668..., --],
                  mask=[False, False,  True,  True, False,  True],
            fill_value=1e+20)
     <BLANKLINE>

--- a/advanced/image_processing/examples/plot_watershed_segmentation.py
+++ b/advanced/image_processing/examples/plot_watershed_segmentation.py
@@ -6,7 +6,7 @@ This example shows how to do segmentation with watershed.
 """
 
 import numpy as np
-from skimage.morphology import watershed
+from skimage.segmentation import watershed
 from skimage.feature import peak_local_max
 import matplotlib.pyplot as plt
 from scipy import ndimage

--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -742,7 +742,7 @@ Label connected components: ``ndimage.label``::
 
     >>> label_im, nb_labels = ndimage.label(mask)
     >>> nb_labels # how many regions?
-    29
+    28
     >>> plt.imshow(label_im)        # doctest: +ELLIPSIS
     <matplotlib.image.AxesImage object at 0x...>
 

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -176,9 +176,9 @@ Brent's method to find the minimum of a function:
     >>> result.success # check if solver was successful
     True
     >>> x_min = result.x
-    >>> x_min #doctest: +ELLIPSIS
+    >>> x_min # doctest: +SKIP
     0.699999999...
-    >>> x_min - 0.7 #doctest: +ELLIPSIS
+    >>> x_min - 0.7 # doctest: +SKIP
     -2.16...e-10
 
 
@@ -380,7 +380,7 @@ be used by setting the parameter ``method`` to CG ::
          fun: 1.6...e-11
          jac: array([-6.15...e-06,   2.53...e-07])
      message: ...'Optimization terminated successfully.'
-        nfev: 108
+        nfev: 81
          nit: 13
         njev: 27
       status: 0
@@ -480,7 +480,7 @@ inversion of the Hessian is performed by conjugate gradient ::
         nfev: 11
         nhev: 0
          nit: 10
-        njev: 52
+        njev: 33
       status: 0
      success: True
            x: array([0.99999...,  0.99999...])
@@ -499,7 +499,7 @@ to the algorithm::
         nfev: 11
         nhev: 10
          nit: 10
-        njev: 20
+        njev: 11
       status: 0
      success: True
            x: array([0.99999...,  0.99999...])
@@ -588,7 +588,7 @@ Full code examples
      hess_inv: array([[0.99986...,  2.0000...],
            [2.0000...,  4.498...]])
           jac: array([  6.7089...e-08,  -3.2222...e-08])
-      message: ...'Optimization terminated successfully.'
+      message: 'Optimization terminated successfully.'
          nfev: 10
           nit: 8
          njev: 10
@@ -610,9 +610,10 @@ are also supported by L-BFGS-B::
           fun: 1.4417...e-15
      hess_inv: <2x2 LbfgsInvHessProduct with dtype=float64>
           jac: array([  1.0233...e-07,  -2.5929...e-08])
-      message: ...'CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL'
+      message: 'CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL'
          nfev: 17
           nit: 16
+         njev: 17
        status: 0
       success: True
             x: array([1.0000...,  1.0000...])
@@ -896,13 +897,13 @@ if we compute the norm ourselves and use a good generic optimizer
           jac: array([...
      ...
                ...])
-      message: ...'Optimization terminated successfully.'
-         nfev: 144
+      message: 'Optimization terminated successfully.'
+         nfev: 132
           nit: 11
          njev: 12
        status: 0
       success: True
-            x: array([-7.3...e-09,   1.1111...e-01,   2.2222...e-01, 3.3333...e-01,
+            x: array([-7...e-09,   1.1111...e-01,   2.2222...e-01, 3.3333...e-01,
             4.4444...e-01,   5.5555...e-01, 6.6666...e-01,   7.7777...e-01,
             8.8889...e-01, 1.0000...e+00])
 
@@ -976,6 +977,7 @@ support bound constraints with the parameter ``bounds``::
       message: ...'CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL'
          nfev: 9
           nit: 2
+         njev: 3
        status: 0
       success: True
             x: array([1.5,  1.5])
@@ -1012,13 +1014,13 @@ and :math:`g(x) < 0`.
     >>> optimize.minimize(f, x0, constraints={"fun": constraint, "type": "ineq"}) #doctest: +ELLIPSIS
          fun: 2.4748...
          jac: array([-0.70708..., -0.70712...])
-     message: ...'Optimization terminated successfully.'
-        nfev: 20
+     message: 'Optimization terminated successfully'
+        nfev: 15
          nit: 5
         njev: 5
       status: 0
      success: True
-           x: array([1.2500...,  0.2499...])
+           x: array([1.2500..., 0.2499...])
 
 
 .. warning:: 

--- a/advanced/scipy_sparse/lil_matrix.rst
+++ b/advanced/scipy_sparse/lil_matrix.rst
@@ -41,7 +41,7 @@ Examples
     >>> mtx[:2, [1, 2, 3]] = data
     >>> mtx  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     <4x5 sparse matrix of type '<... 'numpy.float64'>'
-            with 5 stored elements in LInked List format>
+            with 5 stored elements in List of Lists format>
     >>> print(mtx)   # doctest: +NORMALIZE_WHITESPACE
       (0, 1)  1.0
       (0, 2)  1.0
@@ -75,7 +75,7 @@ Examples
       (2, 3)    1
     >>> mtx[:2, :]  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     <2x4 sparse matrix of type '<... 'numpy.int64'>'
-      with 4 stored elements in LInked List format>
+      with 4 stored elements in List of Lists format>
     >>> mtx[:2, :].todense()    # doctest: +ELLIPSIS
     matrix([[0, 1, 2, 0],
             [3, 0, 1, 0]]...)

--- a/intro/image_processing/image_processing.rst
+++ b/intro/image_processing/image_processing.rst
@@ -33,7 +33,7 @@ Changing orientation, resolution, .. ::
 ::
 
     >>> plt.subplot(151)    # doctest: +ELLIPSIS
-    <matplotlib.axes._subplots.AxesSubplot object at 0x...>
+    <AxesSubplot:>
 
     >>> plt.imshow(shifted_face, cmap=plt.cm.gray)    # doctest: +ELLIPSIS
     <matplotlib.image.AxesImage object at 0x...>

--- a/intro/matplotlib/examples/plot_imshow.py
+++ b/intro/matplotlib/examples/plot_imshow.py
@@ -12,8 +12,8 @@ def f(x, y):
     return (1 - x / 2 + x ** 5 + y ** 3 ) * np.exp(-x ** 2 - y ** 2)
 
 n = 10
-x = np.linspace(-3, 3, 3.5 * n)
-y = np.linspace(-3, 3, 3.0 * n)
+x = np.linspace(-3, 3, int(3.5 * n))
+y = np.linspace(-3, 3, int(3.0 * n))
 X, Y = np.meshgrid(x, y)
 Z = f(X, Y)
 

--- a/intro/numpy/array_object.rst
+++ b/intro/numpy/array_object.rst
@@ -107,7 +107,7 @@ NumPy Reference documentation
    .. sourcecode:: pycon
 
      >>> help(np.array) # doctest: +ELLIPSIS
-     Help on built-in function array in module numpy.core.multiarray:
+     Help on built-in function array in module numpy:
      <BLANKLINE>
      array(...)
          array(object, dtype=None, ...

--- a/intro/numpy/elaborate_arrays.rst
+++ b/intro/numpy/elaborate_arrays.rst
@@ -187,7 +187,7 @@ Multiple fields at once::
     >>> samples[['position', 'value']] # doctest: +NORMALIZE_WHITESPACE
     array([(1. ,  0.37), (1. ,  0.11), (1. ,  0.13), (1.5,  0.37),
            (3. ,  0.11), (1.2,  0.13)],
-          dtype=[('position', '<f8'), ('value', '<f8')])
+          dtype={'names': ['position', 'value'], 'formats': ['<f8', '<f8'], 'offsets': [4, 12], 'itemsize': 20})
 
 Fancy indexing works, as usual::
 

--- a/intro/numpy/exercises.rst
+++ b/intro/numpy/exercises.rst
@@ -126,7 +126,7 @@ northern Canada during 20 years:
 
  >>> import matplotlib.pyplot as plt
  >>> plt.axes([0.2, 0.1, 0.5, 0.8]) # doctest: +ELLIPSIS
- <matplotlib.axes...Axes object at ...>
+ <Axes:> 
  >>> plt.plot(year, hares, year, lynxes, year, carrots) # doctest: +ELLIPSIS
  [<matplotlib.lines.Line2D object at ...>, ...]
  >>> plt.legend(('Hare', 'Lynx', 'Carrot'), loc=(1.05, 0.5)) # doctest: +ELLIPSIS

--- a/intro/scipy.rst
+++ b/intro/scipy.rst
@@ -401,7 +401,7 @@ the location of the minimum that it has found:
      hess_inv: array([[0.0858...]])
           jac: array([-1.19209...e-06])
       message: 'Optimization terminated successfully.'
-         nfev: 18
+         nfev: 12
           nit: 5
          njev: 6
        status: 0
@@ -420,15 +420,16 @@ in general::
 
 
     >>> optimize.minimize(f, x0=0, method="L-BFGS-B")  # doctest: +ELLIPSIS
-          fun: array([-7.94582338])
+          fun: -7.94582338...
      hess_inv: <1x1 LbfgsInvHessProduct with dtype=float64>
-          jac: array([-1.42108547e-06])
-      message: ...'CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL'
+          jac: array([-1.59872117e-06])
+      message: 'CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL'
          nfev: 12
           nit: 5
+         njev: 6
        status: 0
       success: True
-            x: array([-1.30644013])
+            x: array([-1.30644...])
 
 Note how it cost only 12 functions evaluation above to find a good value
 for the minimum.
@@ -442,7 +443,7 @@ global minimum depending on the initial point x0::
 
     >>> res = optimize.minimize(f, x0=3, method="L-BFGS-B")
     >>> res.x
-    array([3.83746709])
+    array([3.83746...])
 
 .. Comment to make doctest pass
    >>> np.random.seed(42)

--- a/intro/summary-exercises/examples/plot_cumulative_wind_speed_prediction.py
+++ b/intro/summary-exercises/examples/plot_cumulative_wind_speed_prediction.py
@@ -16,7 +16,7 @@ years_nb = max_speeds.shape[0]
 cprob = (np.arange(years_nb, dtype=np.float32) + 1)/(years_nb + 1)
 sorted_max_speeds = np.sort(max_speeds)
 speed_spline = UnivariateSpline(cprob, sorted_max_speeds)
-nprob = np.linspace(0, 1, 1e2)
+nprob = np.linspace(0, 1, 100)
 fitted_max_speeds = speed_spline(nprob)
 
 fifty_prob = 1. - 0.02

--- a/intro/summary-exercises/examples/plot_gumbell_wind_speed_prediction.py
+++ b/intro/summary-exercises/examples/plot_gumbell_wind_speed_prediction.py
@@ -20,7 +20,7 @@ sorted_max_speeds = np.sort(max_speeds)
 cprob = (np.arange(years_nb, dtype=np.float32) + 1)/(years_nb + 1)
 gprob = gumbell_dist(cprob)
 speed_spline = UnivariateSpline(gprob, sorted_max_speeds, k=1)
-nprob = gumbell_dist(np.linspace(1e-3, 1-1e-3, 1e2))
+nprob = gumbell_dist(np.linspace(1e-3, 1-1e-3, 100))
 fitted_max_speeds = speed_spline(nprob)
 
 fifty_prob = gumbell_dist(49./50.)

--- a/intro/summary-exercises/stats-interpolate.rst
+++ b/intro/summary-exercises/stats-interpolate.rst
@@ -77,7 +77,7 @@ used because a spline of degree 3 seems to correctly fit the data::
 The quantile function is now going to be evaluated from the full range
 of probabilities::
 
-    >>> nprob = np.linspace(0, 1, 1e2)
+    >>> nprob = np.linspace(0, 1, 100)
     >>> fitted_max_speeds = quantile_func(nprob)
 
 In the current model, the maximum wind speed occurring every 50 years is

--- a/packages/scikit-image/examples/plot_segmentations.py
+++ b/packages/scikit-image/examples/plot_segmentations.py
@@ -11,7 +11,7 @@ background are used as seeds.
 """
 
 import numpy as np
-from skimage.morphology import watershed
+from skimage.segmentation import watershed
 from skimage.feature import peak_local_max
 from skimage import measure
 from skimage.segmentation import random_walker

--- a/packages/scikit-image/index.rst
+++ b/packages/scikit-image/index.rst
@@ -527,10 +527,10 @@ the regions.
 *Watershed* segmentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Watershed (:func:`skimage.morphology.watershed`) is a region-growing
+The Watershed (:func:`skimage.segmentation.watershed`) is a region-growing
 approach that fills "basins" in the image ::
 
-    >>> from skimage.morphology import watershed
+    >>> from skimage.segmentation import watershed
     >>> from skimage.feature import peak_local_max
     >>>
     >>> # Generate an initial image with two overlapping circles

--- a/packages/scikit-learn/examples/plot_separator.py
+++ b/packages/scikit-learn/examples/plot_separator.py
@@ -9,7 +9,7 @@ separating hyperplane on them.
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.linear_model import SGDClassifier
-from sklearn.datasets.samples_generator import make_blobs
+from sklearn.datasets import make_blobs
 
 # we create 50 separable synthetic points
 X, Y = make_blobs(n_samples=50, centers=2,

--- a/packages/scikit-learn/index.rst
+++ b/packages/scikit-learn/index.rst
@@ -711,26 +711,32 @@ The ``DESCR`` variable has a long description of the dataset::
 	:Number of Attributes: 8 numeric, predictive attributes and the target
     <BLANKLINE>
 	:Attribute Information:
-	    - MedInc        median income in block
-	    - HouseAge      median house age in block
-	    - AveRooms      average number of rooms
-	    - AveBedrms     average number of bedrooms
-	    - Population    block population
-	    - AveOccup      average house occupancy
-	    - Latitude      house block latitude
-	    - Longitude     house block longitude
+            - MedInc        median income in block group
+            - HouseAge      median house age in block group
+            - AveRooms      average number of rooms per household
+            - AveBedrms     average number of bedrooms per household
+            - Population    block group population
+            - AveOccup      average number of household members
+            - Latitude      block group latitude
+            - Longitude     block group longitude
     <BLANKLINE>
 	:Missing Attribute Values: None
     <BLANKLINE>
     This dataset was obtained from the StatLib repository.
-    http://lib.stat.cmu.edu/datasets/
+    https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
     <BLANKLINE>
-    The target variable is the median house value for California districts.
+    The target variable is the median house value for California districts,
+    expressed in hundreds of thousands of dollars ($100,000).
     <BLANKLINE>
     This dataset was derived from the 1990 U.S. census, using one row per census
     block group. A block group is the smallest geographical unit for which the U.S.
     Census Bureau publishes sample data (a block group typically has a population
     of 600 to 3,000 people).
+    <BLANKLINE>
+    An household is a group of people residing within a home. Since the average
+    number of rooms and bedrooms in this dataset are provided per household, these
+    columns may take surpinsingly large values for block groups with few households
+    and many empty houses, such as vacation resorts.
     <BLANKLINE>
     It can be downloaded/loaded using the
     :func:`sklearn.datasets.fetch_california_housing` function.

--- a/packages/statistics/examples/plot_iris_analysis.py
+++ b/packages/statistics/examples/plot_iris_analysis.py
@@ -13,7 +13,7 @@ Ilustrate an analysis on a real dataset:
 import matplotlib.pyplot as plt
 
 import pandas
-from pandas.tools import plotting
+from pandas import plotting
 
 from statsmodels.formula.api import ols
 

--- a/packages/statistics/examples/plot_pandas.py
+++ b/packages/statistics/examples/plot_pandas.py
@@ -18,7 +18,7 @@ data = pandas.read_csv('brain_size.csv', sep=';', na_values='.')
 groupby_gender = data.groupby('Gender')
 groupby_gender.boxplot(column=['FSIQ', 'VIQ', 'PIQ'])
 
-from pandas.tools import plotting
+from pandas import plotting
 
 # Scatter matrices for different columns
 plotting.scatter_matrix(data[['Weight', 'Height', 'MRI_Count']])

--- a/packages/statistics/examples/solutions/plot_brain_size.py
+++ b/packages/statistics/examples/solutions/plot_brain_size.py
@@ -31,7 +31,7 @@ print(model.f_test([0, 1, 0, 0]))
 # This plotting is useful to get an intuitions on the relationships between
 # our different variables
 
-from pandas.tools import plotting
+from pandas import plotting
 import matplotlib.pyplot as plt
 
 # Fill in the missing values for Height for plotting

--- a/packages/statistics/index.rst
+++ b/packages/statistics/index.rst
@@ -259,15 +259,15 @@ operations on the resulting group of dataframes::
 Plotting data
 ..............
 
-.. currentmodule:: pandas.tools
+.. currentmodule:: pandas
 
-Pandas comes with some plotting tools (:mod:`pandas.tools.plotting`, using
+Pandas comes with some plotting tools (:mod:`pandas.plotting`, using
 matplotlib behind the scene) to display statistics of the data in
 dataframes:
 
 **Scatter matrices**::
 
-    >>> from pandas.tools import plotting
+    >>> from pandas import plotting
     >>> plotting.scatter_matrix(data[['Weight', 'Height', 'MRI_Count']])   # doctest: +SKIP
 
 .. image:: auto_examples/images/sphx_glr_plot_pandas_002.png
@@ -488,7 +488,7 @@ We can inspect the various statistics derived from the fit::
     Kurtosis:                       2.390   Cond. No.                         3.03
     ==========================...
     <BLANKLINE>
-    Warnings:
+    Notes:
     [1] Standard Errors assume that the covariance matrix of the errors is correctly specified.
 
 
@@ -547,7 +547,7 @@ model::
      Kurtosis:                       1.510   Cond. No.                         2.62
      ==========================...
      <BLANKLINE>
-     Warnings:
+     Notes:
      [1] Standard Errors assume that the covariance matrix of the errors is correctly specified.
 
 .. topic:: **Tips on specifying model**
@@ -585,15 +585,20 @@ model::
      >>> data_piq = pandas.DataFrame({'iq': data['PIQ'], 'type': 'piq'})
      >>> data_long = pandas.concat((data_fisq, data_piq))
      >>> print(data_long)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE 
-              iq  type
-         0   133  fsiq
-         1   140  fsiq
-         2   139  fsiq
-         ...
-         31  137   piq
-         32  110   piq
-         33   86   piq
-         ...
+          iq  type
+     0   133  fsiq
+     1   140  fsiq
+     2   139  fsiq
+     3   133  fsiq
+     4   137  fsiq
+     ...  ...   ...
+     35  128   piq
+     36  124   piq
+     37   94   piq
+     38   74   piq
+     39   89   piq
+     <BLANKLINE>
+     [80 rows x 2 columns]
     
      >>> model = ols("iq ~ type", data_long).fit()
      >>> print(model.summary())  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE +REPORT_UDIFF
@@ -677,7 +682,7 @@ Such a model can be seen in 3D as fitting a plane to a cloud of (`x`,
     Kurtosis:                       3.659   Cond. No.                         54.0
     ==========================...
     <BLANKLINE>
-    Warnings:
+    Notes:
     [1] Standard Errors assume that the covariance matrix of the errors is correctly specified.
 
 |
@@ -696,7 +701,7 @@ test ``"name[T.versicolor] - name[T.virginica]"``, with an `F-test
 <https://en.wikipedia.org/wiki/F-test>`_::
 
     >>> print(model.f_test([0, 1, -1, 0]))  # doctest: +ELLIPSIS
-    <F test: F=array([[3.24533535]]), p=0.07369..., df_denom=146, df_num=1>
+    <F test: F=3.24533535..., p=0.07369..., df_denom=146, df_num=1>
 
 Is this difference significant?
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 # This file is structured in a specific way please include all conda installable
 # libraries before the special comment marked `# For conda, pip installable:`
-numpy>=1.13,<1.17
-scipy==1.3.3
-scikit-learn==0.23
-matplotlib>=2.0,<3.0
-scikit-image>=0.14,<0.15
-sympy>=1.2
-statsmodels==0.10.2
-seaborn==0.9.1
-pandas==0.23.4
-pytest>=7
+numpy>=1.23
+scipy>=1.9
+scikit-learn>=1.1
+matplotlib>=3.5
+scikit-image>=0.19
+sympy>=1.11
+statsmodels>=0.13
+seaborn>=0.12
+pandas>=1.4
+pytest>=7.1
 sphinx>=5.1
-coverage>=6.2
+coverage>=6.4
 pillow
 imageio==2.13.5
 pip
 ipython
 # For conda, pip installable
-sphinx-gallery==0.10.0
+sphinx-gallery>=0.11


### PR DESCRIPTION
@pdebuyl Ready to merge.

Per NEP 29, many core packages dropped support for Python 3.7 after Dec 26, 2021. So we need Python 3.8 to use the latest versions of those packages.