### PR TITLE
Support Matplotlib 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,5 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip list
 
-      - name: Test NetworkX
-        run: make test-to-remove  # FIXME: make test
+      - name: Test lecture notes
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,6 @@ clean:
 test:
 	MATPLOTLIBRC=build_tools $(PYTHON) -m pytest --doctest-glob '*.rst' --ignore advanced/advanced_numpy/examples/myobject_test.py --ignore advanced/interfacing_with_c/numpy_c_api/test_cos_module_np.py --ignore advanced/interfacing_with_c/ctypes/cos_module.py --ignore advanced/interfacing_with_c/swig_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/cython_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/ctypes_numpy/cos_doubles.py --ignore advanced/interfacing_with_c/ctypes_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/numpy_shared/test_cos_doubles.py
 
-test-to-remove:
-	MATPLOTLIBRC=build_tools $(PYTHON) -m pytest --doctest-glob '*.rst' --ignore advanced/advanced_numpy/examples/myobject_test.py --ignore advanced/interfacing_with_c/numpy_c_api/test_cos_module_np.py --ignore advanced/interfacing_with_c/ctypes/cos_module.py --ignore advanced/interfacing_with_c/swig_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/cython_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/ctypes_numpy/cos_doubles.py --ignore advanced/interfacing_with_c/ctypes_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/numpy_shared/test_cos_doubles.py --ignore intro/numpy/array_object.rst --ignore intro/numpy/elaborate_arrays.rst
-
 test-stop-when-failing:
 	MATPLOTLIBRC=build_tools $(PYTHON) -m pytest -x --doctest-glob '*.rst' --ignore advanced/advanced_numpy/examples/myobject_test.py --ignore advanced/interfacing_with_c/numpy_c_api/test_cos_module_np.py --ignore advanced/interfacing_with_c/ctypes/cos_module.py --ignore advanced/interfacing_with_c/swig_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/cython_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/ctypes_numpy/cos_doubles.py --ignore advanced/interfacing_with_c/ctypes_numpy/test_cos_doubles.py --ignore advanced/interfacing_with_c/numpy_shared/test_cos_doubles.py
 

--- a/intro/image_processing/image_processing.rst
+++ b/intro/image_processing/image_processing.rst
@@ -33,7 +33,7 @@ Changing orientation, resolution, .. ::
 ::
 
     >>> plt.subplot(151)    # doctest: +ELLIPSIS
-    <AxesSubplot:>
+    <AxesSubplot: >
 
     >>> plt.imshow(shifted_face, cmap=plt.cm.gray)    # doctest: +ELLIPSIS
     <matplotlib.image.AxesImage object at 0x...>

--- a/intro/matplotlib/examples/plot_plot3d-2.py
+++ b/intro/matplotlib/examples/plot_plot3d-2.py
@@ -8,7 +8,7 @@ Demo 3D plotting with matplotlib and style the figure.
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import axes3d
 
-ax = plt.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
 cset = ax.contourf(X, Y, Z)
 ax.clabel(cset, fontsize=9, inline=1)

--- a/intro/matplotlib/examples/plot_plot3d.py
+++ b/intro/matplotlib/examples/plot_plot3d.py
@@ -9,8 +9,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 
-fig = plt.figure()
-ax = Axes3D(fig)
+ax = plt.figure().add_subplot(projection='3d')
 X = np.arange(-4, 4, 0.25)
 Y = np.arange(-4, 4, 0.25)
 X, Y = np.meshgrid(X, Y)

--- a/intro/numpy/exercises.rst
+++ b/intro/numpy/exercises.rst
@@ -126,7 +126,7 @@ northern Canada during 20 years:
 
  >>> import matplotlib.pyplot as plt
  >>> plt.axes([0.2, 0.1, 0.5, 0.8]) # doctest: +ELLIPSIS
- <Axes:> 
+ <Axes: > 
  >>> plt.plot(year, hares, year, lynxes, year, carrots) # doctest: +ELLIPSIS
  [<matplotlib.lines.Line2D object at ...>, ...]
  >>> plt.legend(('Hare', 'Lynx', 'Carrot'), loc=(1.05, 0.5)) # doctest: +ELLIPSIS

--- a/packages/statistics/examples/plot_regression_3d.py
+++ b/packages/statistics/examples/plot_regression_3d.py
@@ -34,8 +34,7 @@ np.random.seed(1)
 Z = -5 + 3*X - 0.5*Y + 8 * np.random.normal(size=X.shape)
 
 # Plot the data
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 surf = ax.plot_surface(X, Y, Z, cmap=plt.cm.coolwarm,
                        rstride=1, cstride=1)
 ax.view_init(20, -120)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 numpy>=1.23
 scipy>=1.9
 scikit-learn>=1.1
-matplotlib>=3.5
+matplotlib>=3.6
 scikit-image>=0.19
 sympy>=1.11
 statsmodels>=0.13


### PR DESCRIPTION
@pdebuyl Ready to merge.

A few new releases came out in the last few days joblib 1.2, matplotlib 3.6, and pywavelets 1.4. There was a minor doctest output issue with  matplotlib 3.6. This PR fixes that and cleans up two other minor issues I missed in my last PR.