### PR TITLE
Fix sphinx warnings from configuration file

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -9,11 +9,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
 import subprocess
-import sys
 
-import sphinx
 import sphinx_gallery
 from pygments import formatters
 from sphinx import highlighting

--- a/conf.py
+++ b/conf.py
@@ -339,20 +339,20 @@ latex_elements = {
     #'tableofcontents': '\\pagestyle{normal}\\pagenumbering{arabic} %\\tableofcontents',
 }
 
-_python_doc_base = f'https://docs.python.org/{sys.version_info.major}'
+_python_doc_base = 'https://docs.python.org/3/'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': (_python_doc_base, None),
-    'numpy': ('https://numpy.org/doc/stable', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
-    'matplotlib': ('https://matplotlib.org/', None),
-    'sklearn': ('http://scikit-learn.org/stable', None),
-    'sphinx': ('http://www.sphinx-doc.org/en/stable', None),
-    'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
-    'seaborn': ('http://seaborn.pydata.org/', None),
-    'skimage': ('http://scikit-image.org/docs/stable/', None),
-    'statsmodels': ('http://www.statsmodels.org/stable/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
+    'sklearn': ('https://scikit-learn.org/stable/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/stable/', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'seaborn': ('https://seaborn.pydata.org/', None),
+    'skimage': ('https://scikit-image.org/docs/stable/', None),
+    'statsmodels': ('https://www.statsmodels.org/stable/', None),
 }
 
 

--- a/conf.py
+++ b/conf.py
@@ -336,10 +336,10 @@ _python_doc_base = 'https://docs.python.org/3/'
 intersphinx_mapping = {
     'python': (_python_doc_base, None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'sklearn': ('https://scikit-learn.org/stable/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/stable/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'seaborn': ('https://seaborn.pydata.org/', None),
     'skimage': ('https://scikit-image.org/docs/stable/', None),
@@ -348,8 +348,8 @@ intersphinx_mapping = {
 
 
 extlinks = {
-    'simple': (_python_doc_base + '/reference/simple_stmts.html#%s', ''),
-    'compound': (_python_doc_base + '/reference/compound_stmts.html#%s', ''),
+    'simple': (_python_doc_base + '/reference/simple_stmts.html#%s', '%s'),
+    'compound': (_python_doc_base + '/reference/compound_stmts.html#%s', '%s'),
 }
 
 # -- Options for imgmath ------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -72,12 +72,6 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The encoding of source files.
-#source_encoding = 'utf-8'
-
-# The master toctree document.
-master_doc = 'index'
-
 # General information about the project.
 project = "Scipy lecture notes"
 copyright = '2012,2013,2015,2016,2017,2018,2019,2020,2021,2022'
@@ -365,10 +359,6 @@ extlinks = {
 
 imgmath_dvipng_args = ['-gamma 1.5', '-D 180', '-bg', 'Transparent']
 immath_use_preview = True
-
-pngmath_dvipng_args = ['-gamma 1.5', '-D 180', '-bg', 'Transparent']
-pngmath_use_preview = True
-
 
 # Add the 'copybutton' javascript, to hide/show the prompt in code
 # examples

--- a/conf.py
+++ b/conf.py
@@ -9,12 +9,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 import subprocess
-import sphinx
+import sys
 
+import sphinx
 import sphinx_gallery
+from pygments import formatters
+from sphinx import highlighting
 
 # General configuration
 # ---------------------
@@ -22,13 +24,13 @@ import sphinx_gallery
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-        'sphinx.ext.autodoc',
-        'sphinx.ext.doctest',
-        'IPython.sphinxext.ipython_console_highlighting',
-        'sphinx.ext.imgmath',
-        'sphinx.ext.intersphinx',
-        'sphinx.ext.extlinks',
-        'sphinx_gallery.gen_gallery',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'IPython.sphinxext.ipython_console_highlighting',
+    'sphinx.ext.imgmath',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.extlinks',
+    'sphinx_gallery.gen_gallery',
 ]
 
 doctest_test_doctest_blocks = 'true'
@@ -47,7 +49,7 @@ sphinx_gallery_conf = {
                       'packages/scikit-learn/examples',
                       'packages/statistics/examples',
                       'guide/examples',
-                     ],
+                      ],
     'gallery_dirs': ['intro/summary-exercises/auto_examples',
                      'intro/matplotlib/auto_examples',
                      'intro/numpy/auto_examples',
@@ -64,7 +66,7 @@ sphinx_gallery_conf = {
     # The following is necessary to get the links in the code of the
     # examples
     'backreferences_dir': 'tmp',
-    }
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -84,8 +86,8 @@ copyright = '2012,2013,2015,2016,2017,2018,2019,2020,2021,2022'
 # we get this from git
 # this WILL break if we are not in a git-repository
 p = subprocess.Popen(['git', 'describe', '--tags'],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
+                     stdout=subprocess.PIPE,
+                     stderr=subprocess.PIPE)
 p.wait()
 version = p.stdout.read().strip().decode()
 
@@ -131,14 +133,14 @@ pygments_style = 'sphinx'
 
 # Monkey-patch sphinx to set the lineseparator option of pygment, to
 # have indented line wrapping
-from pygments import formatters
+
 
 class MyHtmlFormatter(formatters.HtmlFormatter):
     def __init__(self, **options):
         options['lineseparator'] = '\n<div class="newline"></div>'
         formatters.HtmlFormatter.__init__(self, **options)
 
-from sphinx import highlighting
+
 highlighting.PygmentsBridge.html_formatter = MyHtmlFormatter
 
 # Our substitutions
@@ -182,10 +184,10 @@ html_theme_path = ['themes']
 #html_style = 'default.css'
 
 html_theme_options = {
-                #'nosidebar': 'true',
-                'footerbgcolor': '#000000',
-                'relbarbgcolor': '#000000',
-                }
+    # 'nosidebar': 'true',
+    'footerbgcolor': '#000000',
+    'relbarbgcolor': '#000000',
+}
 
 
 # The name for this set of Sphinx documents.  If None, it defaults to
@@ -264,9 +266,9 @@ latex_show_pagerefs = False
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('index', 'ScipyLectures.tex', r'Scipy lecture notes',
-   r"""Scipy lectures team. Editors: Gaël Varoquaux, Emmanuelle Gouillart, Olav Vahtras""",
-   'manual'),
+    ('index', 'ScipyLectures.tex', r'Scipy lecture notes',
+     r"""Scipy lectures team. Editors: Gaël Varoquaux, Emmanuelle Gouillart, Olav Vahtras""",
+     'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -330,7 +332,7 @@ latex_elements = {
         \makeatother%
         \newpage\newpage
     '''
-    #'tableofcontents': '\\pagestyle{normal}\\pagenumbering{arabic} %\\tableofcontents',
+    # 'tableofcontents': '\\pagestyle{normal}\\pagenumbering{arabic} %\\tableofcontents',
 }
 
 _python_doc_base = 'https://docs.python.org/3/'
@@ -362,5 +364,7 @@ immath_use_preview = True
 
 # Add the 'copybutton' javascript, to hide/show the prompt in code
 # examples
+
+
 def setup(app):
     app.add_js_file('copybutton.js')

--- a/conf.py
+++ b/conf.py
@@ -9,7 +9,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import subprocess
+from subprocess import PIPE, Popen
 
 import sphinx_gallery
 from pygments import formatters
@@ -82,11 +82,9 @@ copyright = '2012,2013,2015,2016,2017,2018,2019,2020,2021,2022'
 # The short X.Y version.
 # we get this from git
 # this WILL break if we are not in a git-repository
-p = subprocess.Popen(['git', 'describe', '--tags'],
-                     stdout=subprocess.PIPE,
-                     stderr=subprocess.PIPE)
-p.wait()
-version = p.stdout.read().strip().decode()
+with Popen(['git', 'describe', '--tags'], stdout=PIPE, stderr=PIPE) as p:
+    p.wait()
+    version = p.stdout.read().strip().decode()
 
 # The full version, including alpha/beta/rc tags.
 release = '2022.1'


### PR DESCRIPTION
@pdebuyl Ready to merge.

This removes all the warnings due to old settings in the sphinx conf.py file. There are still warnings during `make html`, but those are related to actual content and will be addressed in a future PR.