### PR TITLE
Use builtin types

### DIFF
--- a/advanced/image_processing/examples/plot_GMM.py
+++ b/advanced/image_processing/examples/plot_GMM.py
@@ -21,7 +21,7 @@ points = l*np.random.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
-mask = (im > im.mean()).astype(np.float)
+mask = (im > im.mean()).astype(float)
 
 
 img = mask + 0.3*np.random.randn(*mask.shape)

--- a/advanced/image_processing/examples/plot_GMM.py
+++ b/advanced/image_processing/examples/plot_GMM.py
@@ -18,7 +18,7 @@ n = 10
 l = 256
 im = np.zeros((l, l))
 points = l*np.random.random((2, n**2))
-im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
 mask = (im > im.mean()).astype(np.float)

--- a/advanced/image_processing/examples/plot_clean_morpho.py
+++ b/advanced/image_processing/examples/plot_clean_morpho.py
@@ -16,7 +16,7 @@ n = 10
 l = 256
 im = np.zeros((l, l))
 points = l*np.random.random((2, n**2))
-im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
 mask = (im > im.mean()).astype(np.float)

--- a/advanced/image_processing/examples/plot_clean_morpho.py
+++ b/advanced/image_processing/examples/plot_clean_morpho.py
@@ -19,7 +19,7 @@ points = l*np.random.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
-mask = (im > im.mean()).astype(np.float)
+mask = (im > im.mean()).astype(float)
 
 
 img = mask + 0.3*np.random.randn(*mask.shape)

--- a/advanced/image_processing/examples/plot_find_object.py
+++ b/advanced/image_processing/examples/plot_find_object.py
@@ -15,7 +15,7 @@ n = 10
 l = 256
 im = np.zeros((l, l))
 points = l*np.random.random((2, n**2))
-im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
 mask = im > im.mean()

--- a/advanced/image_processing/examples/plot_granulo.py
+++ b/advanced/image_processing/examples/plot_granulo.py
@@ -14,7 +14,7 @@ def disk_structure(n):
     x, y = np.indices((2 * n + 1, 2 * n + 1))
     mask = (x - n)**2 + (y - n)**2 <= n**2
     struct[mask] = 1
-    return struct.astype(np.bool)
+    return struct.astype(bool)
 
 
 def granulometry(data, sizes=None):

--- a/advanced/image_processing/examples/plot_granulo.py
+++ b/advanced/image_processing/examples/plot_granulo.py
@@ -31,7 +31,7 @@ n = 10
 l = 256
 im = np.zeros((l, l))
 points = l*np.random.random((2, n**2))
-im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
 mask = im > im.mean()

--- a/advanced/image_processing/examples/plot_greyscale_dilation.py
+++ b/advanced/image_processing/examples/plot_greyscale_dilation.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 
 im = np.zeros((64, 64))
 np.random.seed(2)
-x, y = (63*np.random.random((2, 8))).astype(np.int)
+x, y = (63*np.random.random((2, 8))).astype(int)
 im[x, y] = np.arange(8)
 
 bigger_points = ndimage.grey_dilation(im, size=(5, 5), structure=np.ones((5, 5)))

--- a/advanced/image_processing/examples/plot_histo_segmentation.py
+++ b/advanced/image_processing/examples/plot_histo_segmentation.py
@@ -17,7 +17,7 @@ points = l*np.random.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
-mask = (im > im.mean()).astype(np.float)
+mask = (im > im.mean()).astype(float)
 
 mask += 0.1 * im
 

--- a/advanced/image_processing/examples/plot_histo_segmentation.py
+++ b/advanced/image_processing/examples/plot_histo_segmentation.py
@@ -14,7 +14,7 @@ n = 10
 l = 256
 im = np.zeros((l, l))
 points = l*np.random.random((2, n**2))
-im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
 mask = (im > im.mean()).astype(np.float)

--- a/advanced/image_processing/examples/plot_measure_data.py
+++ b/advanced/image_processing/examples/plot_measure_data.py
@@ -15,7 +15,7 @@ n = 10
 l = 256
 im = np.zeros((l, l))
 points = l*np.random.random((2, n**2))
-im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
 mask = im > im.mean()

--- a/advanced/image_processing/examples/plot_propagation.py
+++ b/advanced/image_processing/examples/plot_propagation.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 square = np.zeros((32, 32))
 square[10:-10, 10:-10] = 1
 np.random.seed(2)
-x, y = (32*np.random.random((2, 20))).astype(np.int)
+x, y = (32*np.random.random((2, 20))).astype(int)
 square[x, y] = 1
 
 open_square = ndimage.binary_opening(square)

--- a/advanced/image_processing/examples/plot_radial_mean.py
+++ b/advanced/image_processing/examples/plot_radial_mean.py
@@ -17,7 +17,7 @@ X, Y = np.ogrid[0:sx, 0:sy]
 
 r = np.hypot(X - sx/2, Y - sy/2)
 
-rbin = (20* r/r.max()).astype(np.int)
+rbin = (20* r/r.max()).astype(int)
 radial_mean = ndimage.mean(f, labels=rbin, index=np.arange(1, rbin.max() +1))
 
 plt.figure(figsize=(5, 5))

--- a/advanced/image_processing/examples/plot_synthetic_data.py
+++ b/advanced/image_processing/examples/plot_synthetic_data.py
@@ -14,7 +14,7 @@ n = 10
 l = 256
 im = np.zeros((l, l))
 points = l*np.random.random((2, n**2))
-im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
 mask = im > im.mean()

--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -855,7 +855,7 @@ One example with mathematical morphology: `granulometry
     ...     x, y = np.indices((2 * n + 1, 2 * n + 1))
     ...     mask = (x - n)**2 + (y - n)**2 <= n**2
     ...     struct[mask] = 1
-    ...     return struct.astype(np.bool)
+    ...     return struct.astype(bool)
     ...
     >>>
     >>> def granulometry(data, sizes=None):

--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -612,7 +612,7 @@ Segmentation
     >>> im[(points[0]).astype(int), (points[1]).astype(int)] = 1
     >>> im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
-    >>> mask = (im > im.mean()).astype(np.float)
+    >>> mask = (im > im.mean()).astype(float)
     >>> mask += 0.1 * im
     >>> img = mask + 0.2*np.random.randn(*mask.shape)
 

--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -432,7 +432,7 @@ image.
     array([[False,  True, False],
            [ True,  True,  True],
            [False,  True, False]])
-    >>> el.astype(np.int)
+    >>> el.astype(int)
     array([[0, 1, 0],
            [1, 1, 1],
            [0, 1, 0]])
@@ -442,7 +442,7 @@ image.
 
 **Erosion** = minimum filter. Replace the value of a pixel by the minimal value covered by the structuring element.::
 
-    >>> a = np.zeros((7,7), dtype=np.int)
+    >>> a = np.zeros((7,7), dtype=int)
     >>> a[1:6, 2:5] = 1
     >>> a
     array([[0, 0, 0, 0, 0, 0, 0],
@@ -497,7 +497,7 @@ Also works for grey-valued images::
 
     >>> np.random.seed(2)
     >>> im = np.zeros((64, 64))
-    >>> x, y = (63*np.random.random((2, 8))).astype(np.int)
+    >>> x, y = (63*np.random.random((2, 8))).astype(int)
     >>> im[x, y] = np.arange(8)
 
     >>> bigger_points = ndimage.grey_dilation(im, size=(5, 5), structure=np.ones((5, 5)))
@@ -519,7 +519,7 @@ Also works for grey-valued images::
 
 **Opening**: erosion + dilation::
 
-    >>> a = np.zeros((5,5), dtype=np.int)
+    >>> a = np.zeros((5,5), dtype=int)
     >>> a[1:4, 1:4] = 1; a[4, 4] = 1
     >>> a
     array([[0, 0, 0, 0, 0],
@@ -528,14 +528,14 @@ Also works for grey-valued images::
            [0, 1, 1, 1, 0],
            [0, 0, 0, 0, 1]])
     >>> # Opening removes small objects
-    >>> ndimage.binary_opening(a, structure=np.ones((3,3))).astype(np.int)
+    >>> ndimage.binary_opening(a, structure=np.ones((3,3))).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
            [0, 0, 0, 0, 0]])
     >>> # Opening can also smooth corners
-    >>> ndimage.binary_opening(a).astype(np.int)
+    >>> ndimage.binary_opening(a).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 0, 1, 0, 0],
            [0, 1, 1, 1, 0],
@@ -547,7 +547,7 @@ Also works for grey-valued images::
     >>> square = np.zeros((32, 32))
     >>> square[10:-10, 10:-10] = 1
     >>> np.random.seed(2)
-    >>> x, y = (32*np.random.random((2, 20))).astype(np.int)
+    >>> x, y = (32*np.random.random((2, 20))).astype(int)
     >>> square[x, y] = 1
 
     >>> open_square = ndimage.binary_opening(square)
@@ -609,7 +609,7 @@ Segmentation
     >>> im = np.zeros((l, l))
     >>> np.random.seed(1)
     >>> points = l*np.random.random((2, n**2))
-    >>> im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+    >>> im[(points[0]).astype(int), (points[1]).astype(int)] = 1
     >>> im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
 
     >>> mask = (im > im.mean()).astype(np.float)
@@ -732,7 +732,7 @@ Synthetic data::
     >>> l = 256
     >>> im = np.zeros((l, l))
     >>> points = l*np.random.random((2, n**2))
-    >>> im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+    >>> im[(points[0]).astype(int), (points[1]).astype(int)] = 1
     >>> im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
     >>> mask = im > im.mean()
 
@@ -829,7 +829,7 @@ Non-regularly-spaced blocks: radial mean::
     >>> sx, sy = f.shape
     >>> X, Y = np.ogrid[0:sx, 0:sy]
     >>> r = np.hypot(X - sx/2, Y - sy/2)
-    >>> rbin = (20* r/r.max()).astype(np.int)
+    >>> rbin = (20* r/r.max()).astype(int)
     >>> radial_mean = ndimage.mean(f, labels=rbin, index=np.arange(1, rbin.max() +1))
 
 .. figure:: auto_examples/images/sphx_glr_plot_radial_mean_001.png
@@ -872,7 +872,7 @@ One example with mathematical morphology: `granulometry
     >>> l = 256
     >>> im = np.zeros((l, l))
     >>> points = l*np.random.random((2, n**2))
-    >>> im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+    >>> im[(points[0]).astype(int), (points[1]).astype(int)] = 1
     >>> im = ndimage.gaussian_filter(im, sigma=l/(4.*n))
     >>>
     >>> mask = im > im.mean()

--- a/intro/image_processing/image_processing.rst
+++ b/intro/image_processing/image_processing.rst
@@ -53,7 +53,7 @@ Generate a noisy face::
     >>> face = misc.face(gray=True)
     >>> face = face[:512, -512:]  # crop out square on right
     >>> import numpy as np
-    >>> noisy_face = np.copy(face).astype(np.float)
+    >>> noisy_face = np.copy(face).astype(float)
     >>> noisy_face += face.std() * 0.5 * np.random.standard_normal(face.shape)
 
 Apply a variety of filters on it::

--- a/intro/image_processing/image_processing.rst
+++ b/intro/image_processing/image_processing.rst
@@ -103,14 +103,14 @@ Let us first generate a structuring element::
     array([[False, True, False],
            [...True, True, True],
            [False, True, False]])
-    >>> el.astype(np.int)
+    >>> el.astype(int)
     array([[0, 1, 0],
            [1, 1, 1],
            [0, 1, 0]])
 
 * **Erosion** :func:`scipy.ndimage.binary_erosion` ::
 
-    >>> a = np.zeros((7, 7), dtype=np.int)
+    >>> a = np.zeros((7, 7), dtype=int)
     >>> a[1:6, 2:5] = 1
     >>> a
     array([[0, 0, 0, 0, 0, 0, 0],
@@ -157,7 +157,7 @@ Let us first generate a structuring element::
 
 * **Opening** :func:`scipy.ndimage.binary_opening` ::
 
-    >>> a = np.zeros((5, 5), dtype=np.int)
+    >>> a = np.zeros((5, 5), dtype=int)
     >>> a[1:4, 1:4] = 1
     >>> a[4, 4] = 1
     >>> a
@@ -167,14 +167,14 @@ Let us first generate a structuring element::
            [0, 1, 1, 1, 0],
            [0, 0, 0, 0, 1]])
     >>> # Opening removes small objects
-    >>> ndimage.binary_opening(a, structure=np.ones((3, 3))).astype(np.int)
+    >>> ndimage.binary_opening(a, structure=np.ones((3, 3))).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
            [0, 1, 1, 1, 0],
            [0, 0, 0, 0, 0]])
     >>> # Opening can also smooth corners
-    >>> ndimage.binary_opening(a).astype(np.int)
+    >>> ndimage.binary_opening(a).astype(int)
     array([[0, 0, 0, 0, 0],
            [0, 0, 1, 0, 0],
            [0, 1, 1, 1, 0],
@@ -216,7 +216,7 @@ For *gray-valued* images, eroding (resp. dilating) amounts to replacing
 a pixel by the minimal (resp. maximal) value among pixels covered by the
 structuring element centered on the pixel of interest. ::
 
-    >>> a = np.zeros((7, 7), dtype=np.int)
+    >>> a = np.zeros((7, 7), dtype=int)
     >>> a[1:6, 1:6] = 3
     >>> a[4, 4] = 2; a[2, 3] = 1
     >>> a

--- a/intro/scipy/examples/plot_image_filters.py
+++ b/intro/scipy/examples/plot_image_filters.py
@@ -17,7 +17,7 @@ from scipy import signal
 from matplotlib import pyplot as plt
 
 import numpy as np
-noisy_face = np.copy(face).astype(np.float)
+noisy_face = np.copy(face).astype(float)
 noisy_face += face.std() * 0.5 * np.random.standard_normal(face.shape)
 blurred_face = ndimage.gaussian_filter(noisy_face, sigma=3)
 median_face = ndimage.median_filter(noisy_face, size=5)

--- a/intro/summary-exercises/answers_image_processing.rst
+++ b/intro/summary-exercises/answers_image_processing.rst
@@ -47,7 +47,7 @@ Example of solution for the image processing exercise: unmolten grains in glass
 5. Display an image in which the three phases are colored with three
    different colors. ::
 
-    >>> phases = void.astype(np.int) + 2*glass.astype(np.int) + 3*sand.astype(np.int)
+    >>> phases = void.astype(int) + 2*glass.astype(int) + 3*sand.astype(int)
 
    .. image:: ../image_processing/three_phases.png
      :align: center

--- a/packages/scikit-image/examples/plot_boundaries.py
+++ b/packages/scikit-image/examples/plot_boundaries.py
@@ -12,7 +12,7 @@ import numpy as np
 
 coins = data.coins()
 mask = coins > filters.threshold_otsu(coins)
-clean_border = segmentation.clear_border(mask).astype(np.int)
+clean_border = segmentation.clear_border(mask).astype(int)
 
 coins_edges = segmentation.mark_boundaries(coins, clean_border)
 

--- a/packages/scikit-image/examples/plot_labels.py
+++ b/packages/scikit-image/examples/plot_labels.py
@@ -16,7 +16,7 @@ l = 256
 np.random.seed(1)
 im = np.zeros((l, l))
 points = l * np.random.random((2, n ** 2))
-im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = filters.gaussian(im, sigma= l / (4. * n))
 blobs = im > 0.7 * im.mean()
 

--- a/packages/scikit-image/index.rst
+++ b/packages/scikit-image/index.rst
@@ -392,7 +392,7 @@ Default structuring element: 4-connectivity of a pixel ::
 
 **Opening**: erosion + dilation::
 
-    >>> a = np.zeros((5,5), dtype=np.int)
+    >>> a = np.zeros((5,5), dtype=int)
     >>> a[1:4, 1:4] = 1; a[4, 4] = 1
     >>> a
     array([[0, 0, 0, 0, 0],
@@ -494,7 +494,7 @@ Synthetic data::
     >>> l = 256
     >>> im = np.zeros((l, l))
     >>> points = l * np.random.random((2, n ** 2))
-    >>> im[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
+    >>> im[(points[0]).astype(int), (points[1]).astype(int)] = 1
     >>> im = filters.gaussian(im, sigma=l / (4. * n))
     >>> blobs = im > im.mean()
 
@@ -653,7 +653,7 @@ Visualize contour ::
 
 Use ``skimage`` dedicated utility function::
 
-    >>> coins_edges = segmentation.mark_boundaries(coins, clean_border.astype(np.int))
+    >>> coins_edges = segmentation.mark_boundaries(coins, clean_border.astype(int))
 
 .. image:: auto_examples/images/sphx_glr_plot_boundaries_001.png
     :width: 90%


### PR DESCRIPTION
@pdebuyl Rebased on main and ready to merge.

Using the aliases of builtin types like np.int was deprecated in 1.20:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations