### PR TITLE
Update linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,18 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: debug-statements
+      - id: check-added-large-files
       - id: check-ast
-      - id: mixed-line-ending
-      - id: check-yaml
-        args: [--allow-multiple-documents]
+      - id: check-builtin-literals
+      - id: check-case-conflict
       - id: check-json
       - id: check-toml
-      - id: check-added-large-files
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1

--- a/advanced/debugging/segfault.py
+++ b/advanced/debugging/segfault.py
@@ -16,7 +16,7 @@ def print_big_array(small_array):
     return big_array
 
 
-l = list()
+l = []
 for i in range(10):
     a = np.arange(8)
     l.append(print_big_array(a))

--- a/advanced/mathematical_optimization/examples/helper/compare_optimizers.py
+++ b/advanced/mathematical_optimization/examples/helper/compare_optimizers.py
@@ -97,22 +97,22 @@ def mk_costs(ndim=2):
 mem = Memory('.', verbose=3)
 
 if True:
-    gradient_less_benchs = dict()
+    gradient_less_benchs = {}
 
     for ndim in (2, 8, 32, 128):
-        this_dim_benchs = dict()
+        this_dim_benchs = {}
         costs, starting_points = mk_costs(ndim)
         for cost_name, cost_function in costs.items():
             # We don't need the derivative or the hessian
             cost_function = cost_function[0]
-            function_bench = dict()
+            function_bench = {}
             for x0 in starting_points:
-                all_bench = list()
+                all_bench = []
                 # Bench gradient-less
                 for method_name, method in methods.items():
                     if method_name in ('Newton', "L-BFGS w f'"):
                         continue
-                    this_bench = function_bench.get(method_name, list())
+                    this_bench = function_bench.get(method_name, [])
                     this_costs = mem.cache(bencher)(cost_name, ndim,
                                                     method_name, x0)
                     if np.all(this_costs > .25*ndim**2*1e-9):
@@ -134,7 +134,7 @@ if True:
                     if method_name.endswith(" w f'"):
                         this_method_name = method_name[:-4]
                     this_method_name = this_method_name + "\nw f'"
-                    this_bench = function_bench.get(this_method_name, list())
+                    this_bench = function_bench.get(this_method_name, [])
                     this_costs, this_counts = mem.cache(bencher_gradient)(
                                         cost_name, ndim, method_name, x0)
                     if np.all(this_costs > .25*ndim**2*1e-9):
@@ -150,7 +150,7 @@ if True:
 
                 # Bench Newton with Hessian
                 method_name = 'Newton'
-                this_bench = function_bench.get(method_name, list())
+                this_bench = function_bench.get(method_name, [])
                 this_costs, this_counts = mem.cache(bencher_hessian)(cost_name, ndim,
                                                 method_name, x0)
                 if np.all(this_costs > .25*ndim**2*1e-9):

--- a/advanced/mathematical_optimization/examples/helper/cost_functions.py
+++ b/advanced/mathematical_optimization/examples/helper/cost_functions.py
@@ -129,12 +129,12 @@ class LoggingFunction:
     def __init__(self, function, counter=None):
         self.function = function
         if counter is None:
-            counter = list()
+            counter = []
         self.counter = counter
-        self.all_x_i = list()
-        self.all_y_i = list()
-        self.all_f_i = list()
-        self.counts = list()
+        self.all_x_i = []
+        self.all_y_i = []
+        self.all_f_i = []
+        self.counts = []
 
     def __call__(self, x0):
         x_i, y_i = x0[:2]
@@ -151,7 +151,7 @@ class CountingFunction:
     def __init__(self, function, counter=None):
         self.function = function
         if counter is None:
-            counter = list()
+            counter = []
         self.counter = counter
 
     def __call__(self, x0):

--- a/advanced/mathematical_optimization/examples/plot_1d_optim.py
+++ b/advanced/mathematical_optimization/examples/plot_1d_optim.py
@@ -24,8 +24,8 @@ for epsilon in (0, 1):
 
     # Apply brent method. To have access to the iteration, do this in an
     # artificial way: allow the algorithm to iter only once
-    all_x = list()
-    all_y = list()
+    all_x = []
+    all_y = []
     for iter in range(30):
         result = sp.optimize.minimize_scalar(f, bracket=(-5, 2.9, 4.5), method="Brent",
                     options={"maxiter": iter}, tol=np.finfo(1.).eps)

--- a/advanced/mathematical_optimization/examples/plot_constraints.py
+++ b/advanced/mathematical_optimization/examples/plot_constraints.py
@@ -41,7 +41,7 @@ for i in (1, 2):
     plt.axis('off')
 
 # And now plot the optimization path
-accumulator = list()
+accumulator = []
 
 def f(x):
     # Store the list of function calls

--- a/advanced/mathematical_optimization/examples/plot_gradient_descent.py
+++ b/advanced/mathematical_optimization/examples/plot_gradient_descent.py
@@ -42,9 +42,9 @@ def super_fmt(value):
 
 def gradient_descent(x0, f, f_prime, hessian=None, adaptative=False):
     x_i, y_i = x0
-    all_x_i = list()
-    all_y_i = list()
-    all_f_i = list()
+    all_x_i = []
+    all_y_i = []
+    all_f_i = []
 
     for i in range(1, 100):
         all_x_i.append(x_i)
@@ -142,7 +142,7 @@ def nelder_mead(x0, f, f_prime, hessian=None):
 
 ###############################################################################
 # Run different optimizers on these problems
-levels = dict()
+levels = {}
 
 for index, ((f, f_prime, hessian), optimizer) in enumerate((
                 (mk_quad(.7), gradient_descent),

--- a/advanced/mathematical_optimization/examples/plot_non_bounds_constraints.py
+++ b/advanced/mathematical_optimization/examples/plot_non_bounds_constraints.py
@@ -39,7 +39,7 @@ plt.axis('tight')
 plt.axis('off')
 
 # And now plot the optimization path
-accumulator = list()
+accumulator = []
 
 def f(x):
     # Store the list of function calls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.23
 scipy>=1.9
 scikit-learn>=1.1
-matplotlib>=3.6
+matplotlib==3.6.0
 scikit-image>=0.19
 sympy>=1.11
 statsmodels>=0.13


### PR DESCRIPTION
We are getting the following errors with `matplotlib==3.6.1`:
```
Extension error:
Here is a summary of the problems encountered when running the examples

Unexpected failing examples:
/home/jarrod/src/scientific-python/scipy-lecture-notes/packages/statistics/examples/plot_airfare.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/jarrod/src/scientific-python/scipy-lecture-notes/packages/statistics/examples/plot_airfare.py", line 76, in <module>
    seaborn.pairplot(data_flat, vars=['fare', 'dist', 'nb_passengers'],
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/seaborn/axisgrid.py", line 2144, in pairplot
    grid.map_diag(histplot, **diag_kws)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/seaborn/axisgrid.py", line 1507, in map_diag
    func(x=vector, **plot_kwargs)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/seaborn/distributions.py", line 1418, in histplot
    color = _default_color(method, hue, color, kwargs)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/seaborn/utils.py", line 139, in _default_color
    scout, = method([np.nan], [np.nan], **kws)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/matplotlib/__init__.py", line 1423, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/matplotlib/axes/_axes.py", line 2373, in bar
    width = self._convert_dx(width, x0, x, self.convert_xunits)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/matplotlib/axes/_axes.py", line 2182, in _convert_dx
    x0 = cbook._safe_first_finite(x0)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/matplotlib/cbook/__init__.py", line 1749, in _safe_first_finite
    return next(val for val in obj if safe_isfinite(val))
StopIteration


/home/jarrod/src/scientific-python/scipy-lecture-notes/packages/statistics/examples/plot_wage_data.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/jarrod/src/scientific-python/scipy-lecture-notes/packages/statistics/examples/plot_wage_data.py", line 62, in <module>
    seaborn.pairplot(data, vars=['WAGE', 'AGE', 'EDUCATION'],
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/seaborn/axisgrid.py", line 2144, in pairplot
    grid.map_diag(histplot, **diag_kws)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/seaborn/axisgrid.py", line 1507, in map_diag
    func(x=vector, **plot_kwargs)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/seaborn/distributions.py", line 1418, in histplot
    color = _default_color(method, hue, color, kwargs)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/seaborn/utils.py", line 139, in _default_color
    scout, = method([np.nan], [np.nan], **kws)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/matplotlib/__init__.py", line 1423, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/matplotlib/axes/_axes.py", line 2373, in bar
    width = self._convert_dx(width, x0, x, self.convert_xunits)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/matplotlib/axes/_axes.py", line 2182, in _convert_dx
    x0 = cbook._safe_first_finite(x0)
  File "/home/jarrod/.venv/lectures38/lib64/python3.8/site-packages/matplotlib/cbook/__init__.py", line 1749, in _safe_first_finite
    return next(val for val in obj if safe_isfinite(val))
StopIteration
```

Pinning `matplotlib==3.6.0` for now and will deal with this issue in a subsequent PR.