### PR TITLE
update plot_contour.py keyword argument warning

### DIFF
--- a/intro/matplotlib/examples/plot_contour.py
+++ b/intro/matplotlib/examples/plot_contour.py
@@ -20,7 +20,7 @@ X,Y = np.meshgrid(x, y)
 plt.axes([0.025, 0.025, 0.95, 0.95])
 
 plt.contourf(X, Y, f(X, Y), 8, alpha=.75, cmap=plt.cm.hot)
-C = plt.contour(X, Y, f(X, Y), 8, colors='black', linewidth=.5)
+C = plt.contour(X, Y, f(X, Y), 8, colors='black', linewidths=.5)
 plt.clabel(C, inline=1, fontsize=10)
 
 plt.xticks([])


### PR DESCRIPTION
The 'linewidth' argument is not used by the matplotlib contour method. Instead, consider using the 'linewidths' argument