### PR TITLE
Fix rendering of horizontal lists

### DIFF
--- a/themes/scipy_lectures/static/nature.css_t
+++ b/themes/scipy_lectures/static/nature.css_t
@@ -70,6 +70,12 @@ ul.horizontal li:before {
     margin-left: 1.5ex;
 }
 
+/* On a horizontal table, if the list item has only one paragraph
+   child, render that child inline instead of as a paragraph */
+ul.horizontal li p:first-child:nth-last-child(1) {
+    display: inline-block;
+}
+
 div.body p {
    line-height: 1.45;
 }


### PR DESCRIPTION
List item contents are now wrapped in `<p></p>` tags.  This workaround is fine for single item lists, but not for longer sentences, but it looks as though `rst-class:: horizontal` is exclusively used for short items, such as pre-requisites.

Partially resolves https://github.com/scipy-lectures/scipy-lecture-notes/issues/550