### PR TITLE
Use :start-line: to avoid rendering of :orphan: from included files

### DIFF
--- a/advanced/index.rst
+++ b/advanced/index.rst
@@ -10,6 +10,7 @@ tackles various specific topics.
 |
 
 .. include:: ../includes/big_toc_css.rst
+   :start-line: 1
 
 .. include:: ../tune_toc.rst
 

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -45,6 +45,7 @@ used for more efficient, non black-box, optimization.
      <https://www.amazon.com/gp/product/0471494631/ref=ox_sc_act_title_1?ie=UTF8&smid=ATVPDKIKX0DER>`_ by Fletcher: good at hand-waving explanations.
 
 .. include:: ../../includes/big_toc_css.rst
+   :start-line: 1
 
 
 .. contents:: Chapters contents
@@ -543,7 +544,7 @@ Full code examples
    declaration
 
 .. include:: auto_examples/index.rst
-    :start-line: 1
+   :start-line: 1
 
 
 .. |bfgs_rosen_icond| image:: auto_examples/images/sphx_glr_plot_gradient_descent_014.png

--- a/intro/index.rst
+++ b/intro/index.rst
@@ -9,6 +9,7 @@ itself, to numerical computing or plotting.
 
 
 .. include:: ../includes/big_toc_css.rst
+   :start-line: 1
 
 .. include:: ../tune_toc.rst
 

--- a/intro/numpy/index.rst
+++ b/intro/numpy/index.rst
@@ -17,6 +17,7 @@ numerical computing with Python.
 ____
 
 .. include:: ../../includes/big_toc_css.rst
+   :start-line: 1
 
 .. toctree::
    array_object.rst

--- a/packages/index.rst
+++ b/packages/index.rst
@@ -10,6 +10,7 @@ packages useful for extended needs.
 
 
 .. include:: ../includes/big_toc_css.rst
+   :start-line: 1
 
 .. include:: ../tune_toc.rst
 


### PR DESCRIPTION
Oddly, sphinx does not provide a good way to do this out of the box. Their recommended approach is to rename included files to have some other extension, so Sphinx does not try to build pages for those files :thinking: 

Instead, I am using a pattern I found elsewhere in the lecture notes.

Partially closes https://github.com/scipy-lectures/scipy-lecture-notes/issues/550