### PR TITLE
Fix topic rendering

### DIFF
--- a/themes/scipy_lectures/static/nature.css_t
+++ b/themes/scipy_lectures/static/nature.css_t
@@ -710,7 +710,7 @@ table.field-list {
 }
 
 /* Boxes */
-div.topic, div.admonition {
+aside.topic, div.admonition {
     border-radius: 4px 4px 4px 4px;
     display: flow-root;
 }
@@ -721,7 +721,7 @@ div.sidebar {
     max-width: 40%;
 }
 
-div.topic {
+aside.topic {
     background-color: #F9F9F9;
     margin-top: 15px;
     padding-top: 3px;


### PR DESCRIPTION
Sphinx now renders these as `<aside class="topic">`.

This is the box in which the prerequisites appear.

Partially closes https://github.com/scipy-lectures/scipy-lecture-notes/issues/550