### PR TITLE
docutils: generate colspec for tables

### DIFF
--- a/docutils.conf
+++ b/docutils.conf
@@ -1,0 +1,2 @@
+[html writers]
+table_style: colwidths-grid


### PR DESCRIPTION
This is a change introduced in `docutils` 0.18:

  - Only specify table column widths, if the `"widths" option`_ is set and is not "auto" (fixes bug #426). https://sourceforge.net/p/docutils/bugs/426/

By default, `docutils` now lets the browser decide the width of a table. Usually, that's what you want, but we prefer our tables to have two equally sized columns when doing comparisons.

`docutils` uses the following conditions to determine whether to avoid writing a colgroup tag:

```python
if 'colwidths-auto' in node.parent.parent['classes'] or (
    'colwidths-grid' not in self.settings.table_style
    and 'colwidths-given' not in node.parent.parent['classes']):
    return
```

So, after adding `table_style: colwidths_grid` to `docutils.py`, we get the old behavior back. To get browser column balancing, use:

```rst
.. list-table:: Title
   :widths: auto
```

Partially closes https://github.com/scipy-lectures/scipy-lecture-notes/issues/550