### PR TITLE
Render math with dvisvgm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
       - run:
           name: Install TeX
-          command: sudo apt-get install dvipng texlive-latex-base texlive-latex-extra
+          command: sudo apt-get install dvisvgm texlive-latex-base texlive-latex-extra
 
       - restore_cache:
           keys:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -91,5 +91,5 @@ Note that you will also need the following system packages:
    <https://www.tug.org/texlive/>`__ (``texlive``,
    ``texlive-latex-extra``, ``texlive-fonts-extra``, and ``latexmk``
    on Debian/Ubuntu),
- - `dvipng <http://savannah.nongnu.org/projects/dvipng/>`__, and
+ - `dvisvgm <https://dvisvgm.de/>`__, and
  - `git <https://git-scm.com/>`__.

--- a/conf.py
+++ b/conf.py
@@ -357,7 +357,8 @@ extlinks = {
 
 # -- Options for imgmath ------------------------------------------------
 
-imgmath_dvipng_args = ['-gamma 1.5', '-D 180', '-bg', 'Transparent']
+imgmath_image_format = 'svg'
+imgmath_dvisvgm_args = ['--no-fonts', '--zoom=1.1']
 immath_use_preview = True
 
 # Add the 'copybutton' javascript, to hide/show the prompt in code


### PR DESCRIPTION
This unfortunately renders the math thinner, so we may want to stick with dvipng for now, despite the larger output files (font size issue can probably be fixed there).