### PR TITLE
Rename project to Scientific Python lecture notes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,7 @@
 Contributing
 =============
 
-The Scientific Python lecture notes are a community-based effort and require
+The Scientific Python Lecture Notes are a community-based effort and require
 constant maintenance and improvements. New contributions such as wording
 improvements or inclusion of new topics are welcome.
 
@@ -17,7 +17,7 @@ Objectives and design choices for the lecture notes
 ---------------------------------------------------
 
 Contributors should keep the following objectives and design choices of
-the Scientific Python lecture notes in mind.
+the Scientific Python Lecture Notes in mind.
 
 Objectives:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,8 +1,8 @@
 Contributing
 =============
 
-The SciPy lecture notes are a community-based effort and require constant
-maintenance and improvements. New contributions such as wording
+The Scientific Python lecture notes are a community-based effort and require
+constant maintenance and improvements. New contributions such as wording
 improvements or inclusion of new topics are welcome.
 
 To propose bugfixes or straightforward improvements to the notes, see the
@@ -17,7 +17,7 @@ Objectives and design choices for the lecture notes
 ---------------------------------------------------
 
 Contributors should keep the following objectives and design choices of
-the SciPy lecture notes in mind.
+the Scientific Python lecture notes in mind.
 
 Objectives:
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ latex: cleandoctrees
 	mkdir -p build/latex build/doctrees
 	$(SPHINXBUILD) -b $@ $(ALLSPHINXOPTS) build/latex
 	sed -i -e 's/\\sphinxincludegraphics/\
-\\sphinxincludegraphics/g' build/latex/ScipyLectures.tex
+\\sphinxincludegraphics/g' build/latex/ScientificPythonLectures.tex
 	@echo
 	@echo "Build finished; the LaTeX files are in build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
@@ -102,21 +102,21 @@ linkcheck:
 	      "or in build/linkcheck/output.txt."
 
 pdf: latex
-	cd build/latex ; make all-pdf ; pdfjam --outfile ScipyLectures-nup.pdf --nup 2x1 --landscape ScipyLectures.pdf
-	cp build/latex/ScipyLectures.pdf ScipyLectures-simple.pdf
-	cp build/latex/ScipyLectures-nup.pdf ScipyLectures.pdf
+	cd build/latex ; make all-pdf ; pdfjam --outfile ScientificPythonLectures-nup.pdf --nup 2x1 --landscape ScientificPythonLectures.pdf
+	cp build/latex/ScientificPythonLectures.pdf ScientificPythonLectures-simple.pdf
+	cp build/latex/ScientificPythonLectures-nup.pdf ScientificPythonLectures.pdf
 
 zip: clean html pdf
 	mkdir -p build/scipy_lecture_notes ;
-	cp ScipyLectures.pdf ScipyLectures-simple.pdf build/html/_downloads/
+	cp ScientificPythonLectures.pdf ScientificPythonLectures-simple.pdf build/html/_downloads/
 	cp -r data build/html/
 	cd build/html ; zip -r ../scipy-lecture-notes-html-$(TAG).zip .
-	cp ScipyLectures.pdf build/ ;
+	cp ScientificPythonLectures.pdf build/ ;
 	git archive -o build/scipy-lecture-notes-source-$(TAG).zip --prefix scipy-lecture-notes-$(TAG)/ $(TAG)
 
 install: cleandoctrees html pdf
 	rm -rf build/scipy-lectures.github.com
-	cp ScipyLectures.pdf ScipyLectures-simple.pdf build/html/_downloads/
+	cp ScientificPythonLectures.pdf ScientificPythonLectures-simple.pdf build/html/_downloads/
 	cd build/ && \
 	git clone  --no-checkout --depth 1 git@github.com:scipy-lectures/scipy-lectures.github.com.git && \
 	cp -r html/* scipy-lectures.github.com && \
@@ -128,7 +128,7 @@ install: cleandoctrees html pdf
 	git push
 
 rsync_upload: check-rsync-env cleandoctrees html pdf
-	cp ScipyLectures-simple.pdf ScipyLectures.pdf build/html/_downloads/
+	cp ScientificPythonLectures-simple.pdf ScientificPythonLectures.pdf build/html/_downloads/
 	rsync -P -auvz --delete build/html/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)/
 
 check-rsync-env:

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 Scientific-Python-Lecture-Notes
 ===============================
 
-This repository gathers some lecture notes on the Scientific Python
+This repository gathers some lecture notes on the scientific Python
 ecosystem that can be used for a full course of scientific computing with
 Python.
 

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,11 @@
 .. image:: https://github.com/scipy-lectures/scipy-lecture-notes/workflows/test/badge.svg?branch=main
   :target: https://github.com/scipy-lectures/scipy-lecture-notes/actions?query=workflow%3A%22test%22
 
-===================
-Scipy-Lecture-Notes
-===================
+===============================
+Scientific-Python-Lecture-Notes
+===============================
 
-This repository gathers some lecture notes on the scientific Python
+This repository gathers some lecture notes on the Scientific Python
 ecosystem that can be used for a full course of scientific computing with
 Python.
 

--- a/about.rst
+++ b/about.rst
@@ -1,11 +1,11 @@
 .. only:: latex
 
    =========================================
-   About the Scientific Python lecture notes
+   About the Scientific Python Lecture Notes
    =========================================
 
 
-   About the Scientific Python lecture notes
+   About the Scientific Python Lecture Notes
    =========================================
 
    Release: |release|

--- a/about.rst
+++ b/about.rst
@@ -1,12 +1,12 @@
 .. only:: latex
 
-   =============================
-   About the SciPy lecture notes
-   =============================
+   =========================================
+   About the Scientific Python lecture notes
+   =========================================
 
 
-   About the SciPy lecture notes
-   =============================
+   About the Scientific Python lecture notes
+   =========================================
 
    Release: |release|
 

--- a/advanced/index.rst
+++ b/advanced/index.rst
@@ -3,8 +3,8 @@
 Advanced topics
 ================
 
-This part of the *Scipy lecture notes* is dedicated to advanced usage. It
-strives to educate the proficient Python coder to be an expert and
+This part of the *Scientific Python lecture notes* is dedicated to advanced
+usage. It strives to educate the proficient Python coder to be an expert and
 tackles various specific topics.
 
 |

--- a/advanced/index.rst
+++ b/advanced/index.rst
@@ -3,7 +3,7 @@
 Advanced topics
 ================
 
-This part of the *Scientific Python lecture notes* is dedicated to advanced
+This part of the *Scientific Python Lecture Notes* is dedicated to advanced
 usage. It strives to educate the proficient Python coder to be an expert and
 tackles various specific topics.
 

--- a/conf.py
+++ b/conf.py
@@ -8,7 +8,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
+from datetime import date
 from subprocess import PIPE, Popen
 
 import sphinx_gallery
@@ -75,8 +75,8 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 
 # General information about the project.
-project = "Scipy lecture notes"
-copyright = '2012,2013,2015,2016,2017,2018,2019,2020,2021,2022'
+project = "Scientific Python lecture notes"
+copyright = f'{date.today().year}'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -190,10 +190,10 @@ html_theme_options = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "Scipy lecture notes"
+html_title = "Scientific Python lecture notes"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = "Scipy"
+#html_short_title = ""
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -245,7 +245,7 @@ html_use_index = False
 #html_file_suffix = ''
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ScipyLectures'
+htmlhelp_basename = 'ScientificPythonLectures'
 
 # Options for epub output
 # ------------------------
@@ -264,8 +264,8 @@ latex_show_pagerefs = False
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-    ('index', 'ScipyLectures.tex', r'Scipy lecture notes',
-     r"""Scipy lectures team. Editors: Gaël Varoquaux, Emmanuelle Gouillart, Olav Vahtras""",
+    ('index', 'ScientificPythonLectures.tex', r'Scientific Python lecture notes',
+     r"""Scientific Python lectures team. Editors: Gaël Varoquaux, Emmanuelle Gouillart, Olav Vahtras""",
      'manual'),
 ]
 

--- a/conf.py
+++ b/conf.py
@@ -75,7 +75,7 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 
 # General information about the project.
-project = "Scientific Python lecture notes"
+project = "Scientific Python Lecture Notes"
 copyright = f'{date.today().year}'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -190,7 +190,7 @@ html_theme_options = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "Scientific Python lecture notes"
+html_title = "Scientific Python Lecture Notes"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = ""
@@ -264,7 +264,7 @@ latex_show_pagerefs = False
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-    ('index', 'ScientificPythonLectures.tex', r'Scientific Python lecture notes',
+    ('index', 'ScientificPythonLectures.tex', r'Scientific Python Lecture Notes',
      r"""Scientific Python lectures team. Editors: Gaël Varoquaux, Emmanuelle Gouillart, Olav Vahtras""",
      'manual'),
 ]

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -149,8 +149,8 @@ In restructured-text markup this is::
 Linking to package documentations
 ==================================
 
-The goal of the scipy lecture notes is not to duplicate or replace the
-documentation of the various packages. You should link as much as
+The goal of the Scientific Python lecture notes is not to duplicate or replace
+the documentation of the various packages. You should link as much as
 possible to the original documentation.
 
 For cross-referencing API documentation we prefer to use the `intersphinx

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -149,7 +149,7 @@ In restructured-text markup this is::
 Linking to package documentations
 ==================================
 
-The goal of the Scientific Python lecture notes is not to duplicate or replace
+The goal of the Scientific Python Lecture Notes is not to duplicate or replace
 the documentation of the various packages. You should link as much as
 possible to the original documentation.
 

--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,5 @@
-Scipy Lecture Notes
-===========================
+Scientific Python Lecture Notes
+===============================
 
 .. only:: html
 
@@ -75,9 +75,9 @@ Scipy Lecture Notes
 
     .. sidebar::  Download
 
-       |pdf| `PDF, 2 pages per side <./_downloads/ScipyLectures.pdf>`_
+       |pdf| `PDF, 2 pages per side <./_downloads/ScientificPythonLectures.pdf>`_
 
-       |pdf| `PDF, 1 page per side <./_downloads/ScipyLectures-simple.pdf>`_
+       |pdf| `PDF, 1 page per side <./_downloads/ScientificPythonLectures-simple.pdf>`_
 
        |archive| `HTML and example files <https://github.com/scipy-lectures/scipy-lectures.github.com/zipball/main>`_
 
@@ -122,7 +122,7 @@ Scipy Lecture Notes
 
    <div style='display: none; height=0px;'>
 
- :download:`ScipyLectures.pdf` :download:`ScipyLectures-simple.pdf`
+ :download:`ScientificPythonLectures.pdf` :download:`ScientificPythonLectures-simple.pdf`
 
  .. image:: themes/plusBox.png
 

--- a/intro/help/help.rst
+++ b/intro/help/help.rst
@@ -122,7 +122,7 @@ Finally, two more "technical" possibilities are useful as well:
 * If everything listed above fails (and Google doesn't have the
   answer)... don't despair! Write to the mailing-list suited to your
   problem: you should have a quick answer if you describe your problem
-  well. Experts on scientific python often give very enlightening
+  well. Experts on scientific Python often give very enlightening
   explanations on the mailing-list.
 
     * **Numpy discussion** (numpy-discussion@scipy.org): all about numpy

--- a/intro/index.rst
+++ b/intro/index.rst
@@ -1,7 +1,8 @@
 Getting started with Python for science
 ===================================================================
 
-This part of the *Scipy lecture notes* is a self-contained introduction to
+This part of the *Scientific Python lecture notes* is a self-contained
+introduction to
 everything that is needed to use Python for science, from the language
 itself, to numerical computing or plotting.
 

--- a/intro/index.rst
+++ b/intro/index.rst
@@ -1,7 +1,7 @@
 Getting started with Python for science
 ===================================================================
 
-This part of the *Scientific Python lecture notes* is a self-contained
+This part of the *Scientific Python Lecture Notes* is a self-contained
 introduction to
 everything that is needed to use Python for science, from the language
 itself, to numerical computing or plotting.

--- a/intro/intro.rst
+++ b/intro/intro.rst
@@ -140,8 +140,8 @@ Python
   * Not all the algorithms that can be found in more specialized
     software or toolboxes.
 
-The Scientific Python ecosystem
---------------------------------
+The scientific Python ecosystem
+-------------------------------
 
 Unlike Matlab, or R, Python does not come with a pre-bundled set
 of modules for scientific computing. Below are the basic building blocks
@@ -255,7 +255,7 @@ packaged, and it is recommended to use your package manager.
 
 **Other systems**
 
-There are several fully-featured Scientific Python distributions:
+There are several fully-featured scientific Python distributions:
 
 
 

--- a/intro/language/reusing_code.rst
+++ b/intro/language/reusing_code.rst
@@ -507,8 +507,8 @@ ____
 
 .. topic:: **Quick read**
 
-   If you want to do a first quick pass through the Scientific Python lectures
-   to learn the ecosystem, you can directly skip to the next chapter:
+   If you want to do a first quick pass through the Scientific Python Lecture
+   Notes to learn the ecosystem, you can directly skip to the next chapter:
    :ref:`numpy`.
 
    The remainder of this chapter is not necessary to follow the rest of

--- a/intro/language/reusing_code.rst
+++ b/intro/language/reusing_code.rst
@@ -507,8 +507,8 @@ ____
 
 .. topic:: **Quick read**
 
-   If you want to do a first quick pass through the Scipy lectures to
-   learn the ecosystem, you can directly skip to the next chapter:
+   If you want to do a first quick pass through the Scientific Python lectures
+   to learn the ecosystem, you can directly skip to the next chapter:
    :ref:`numpy`.
 
    The remainder of this chapter is not necessary to follow the rest of

--- a/intro/matplotlib/index.rst
+++ b/intro/matplotlib/index.rst
@@ -1028,8 +1028,8 @@ ____
 
 .. topic:: **Quick read**
 
-   If you want to do a first quick pass through the Scientific Python lectures
-   to learn the ecosystem, you can directly skip to the next chapter:
+   If you want to do a first quick pass through the Scientific Python Lecture
+   Notes to learn the ecosystem, you can directly skip to the next chapter:
    :ref:`scipy`.
 
    The remainder of this chapter is not necessary to follow the rest of

--- a/intro/matplotlib/index.rst
+++ b/intro/matplotlib/index.rst
@@ -1028,8 +1028,8 @@ ____
 
 .. topic:: **Quick read**
 
-   If you want to do a first quick pass through the Scipy lectures to
-   learn the ecosystem, you can directly skip to the next chapter:
+   If you want to do a first quick pass through the Scientific Python lectures
+   to learn the ecosystem, you can directly skip to the next chapter:
    :ref:`scipy`.
 
    The remainder of this chapter is not necessary to follow the rest of

--- a/intro/numpy/operations.rst
+++ b/intro/numpy/operations.rst
@@ -869,8 +869,8 @@ Summary
 
 .. topic:: **Quick read**
 
-   If you want to do a first quick pass through the Scipy lectures to
-   learn the ecosystem, you can directly skip to the next chapter:
+   If you want to do a first quick pass through the Scientific Python lectures
+   to learn the ecosystem, you can directly skip to the next chapter:
    :ref:`matplotlib`.
 
    The remainder of this chapter is not necessary to follow the rest of

--- a/intro/numpy/operations.rst
+++ b/intro/numpy/operations.rst
@@ -869,8 +869,8 @@ Summary
 
 .. topic:: **Quick read**
 
-   If you want to do a first quick pass through the Scientific Python lectures
-   to learn the ecosystem, you can directly skip to the next chapter:
+   If you want to do a first quick pass through the Scientific Python Lecture
+   Notes to learn the ecosystem, you can directly skip to the next chapter:
    :ref:`matplotlib`.
 
    The remainder of this chapter is not necessary to follow the rest of

--- a/packages/index.rst
+++ b/packages/index.rst
@@ -3,7 +3,7 @@
 Packages and applications
 ==========================
 
-This part of the *Scientific Python lecture notes* is dedicated to various
+This part of the *Scientific Python Lecture Notes* is dedicated to various
 scientific packages useful for extended needs.
 
 |

--- a/packages/index.rst
+++ b/packages/index.rst
@@ -3,8 +3,8 @@
 Packages and applications
 ==========================
 
-This part of the *Scipy lecture notes* is dedicated to various scientific
-packages useful for extended needs.
+This part of the *Scientific Python lecture notes* is dedicated to various
+scientific packages useful for extended needs.
 
 |
 

--- a/packages/scikit-image/index.rst
+++ b/packages/scikit-image/index.rst
@@ -81,7 +81,7 @@ Images are NumPy's arrays ``np.ndarray``
 ``scikit-image`` and the ``SciPy`` ecosystem
 ---------------------------------------------
 
-Recent versions of ``scikit-image`` is packaged in most Scientific Python
+Recent versions of ``scikit-image`` is packaged in most scientific Python
 distributions, such as Anaconda or Enthought Canopy. It is also packaged
 for Ubuntu/Debian.
 

--- a/preface.rst
+++ b/preface.rst
@@ -1,5 +1,5 @@
 =========================================
-About the Scientific Python lecture notes
+About the Scientific Python Lecture Notes
 =========================================
 
 .. contents::

--- a/preface.rst
+++ b/preface.rst
@@ -1,6 +1,6 @@
-=============================
-About the scipy lecture notes
-=============================
+=========================================
+About the Scientific Python lecture notes
+=========================================
 
 .. contents::
    :local:

--- a/pyximages/README.md
+++ b/pyximages/README.md
@@ -1,6 +1,7 @@
 # Content of directory pyximages
 
-This directory contains files related to schematic drawings in the Scipy
+This directory contains files related to schematic drawings in the
+Scientific Python
 Lecture Notes which cannot be produced by means of matplotlib in a simple way
 and for which no source exists in the repository so far. For each image, a
 Python source using PyX, a bitmap image for the HTML version, and a PDF


### PR DESCRIPTION
As discussed during today at the Scientific Python summit, I propose to rename the project to "Scientific Python lecture notes".

This removes yet another confusion in the current state of the ecosystem and clarify that this is not part of the SciPy library (which is a trademark concern on its own.)

If/once this is approved, the name of the repository should be changed accordingly. (And there is going to be the question about the web domain and where/how this website is administrated.)

cc @jarrodmillman 