### PR TITLE
MAINT: remove duplicate eigenfaces header

### DIFF
--- a/packages/scikit-learn/examples/plot_eigenfaces.py
+++ b/packages/scikit-learn/examples/plot_eigenfaces.py
@@ -2,13 +2,6 @@
 The eigenfaces example: chaining PCA and SVMs
 =============================================
 
-
-.. sidebar:: Code and notebook
-
-   Python code and Jupyter notebook for this section are found
-   :ref:`here
-   <sphx_glr_packages_scikit-learn_auto_examples_plot_eigenfaces.py>`
-
 The goal of this example is to show how an unsupervised method and a
 supervised one can be chained for better prediction. It starts with a
 didactic but lengthy way of doing things, and finishes with the

--- a/packages/scikit-learn/examples/plot_eigenfaces.py
+++ b/packages/scikit-learn/examples/plot_eigenfaces.py
@@ -2,6 +2,13 @@
 The eigenfaces example: chaining PCA and SVMs
 =============================================
 
+
+.. sidebar:: Code and notebook
+
+   Python code and Jupyter notebook for this section are found
+   :ref:`here
+   <sphx_glr_packages_scikit-learn_auto_examples_plot_eigenfaces.py>`
+
 The goal of this example is to show how an unsupervised method and a
 supervised one can be chained for better prediction. It starts with a
 didactic but lengthy way of doing things, and finishes with the

--- a/packages/scikit-learn/index.rst
+++ b/packages/scikit-learn/index.rst
@@ -1358,11 +1358,6 @@ of digits eventhough it had no access to the class information.
         >>> # ...
 
 
-.. The eigenfaces example: chaining PCA and SVMs
-.. =============================================
-
-
-.. include:: auto_examples/plot_eigenfaces.rst
     :start-line: 7
     :end-before: plt.show()
 

--- a/packages/scikit-learn/index.rst
+++ b/packages/scikit-learn/index.rst
@@ -1358,14 +1358,8 @@ of digits eventhough it had no access to the class information.
         >>> # ...
 
 
-The eigenfaces example: chaining PCA and SVMs
-=============================================
-
-.. sidebar:: Code and notebook
-
-   Python code and Jupyter notebook for this section are found
-   :ref:`here
-   <sphx_glr_packages_scikit-learn_auto_examples_plot_eigenfaces.py>`
+.. The eigenfaces example: chaining PCA and SVMs
+.. =============================================
 
 
 .. include:: auto_examples/plot_eigenfaces.rst

--- a/packages/scikit-learn/index.rst
+++ b/packages/scikit-learn/index.rst
@@ -1357,12 +1357,6 @@ of digits eventhough it had no access to the class information.
         >>> digits = load_digits()
         >>> # ...
 
-
-    :start-line: 7
-    :end-before: plt.show()
-
-
-
 Parameter selection, Validation, and Testing
 =============================================
 


### PR DESCRIPTION
Closes gh-560

I removed the header from the index rather than `plot_eigenfaces.py` in case `plot_eigenfaces.py` is accessed as a stand-alone document. Need to check with the sidebar thing works properly.