### PR TITLE
Fix out-of-bound  conversion warning

### DIFF
--- a/advanced/advanced_numpy/index.rst
+++ b/advanced/advanced_numpy/index.rst
@@ -1264,7 +1264,7 @@ Imaging Library):
 .. seealso:: pilbuffer.py
 
 >>> from PIL import Image
->>> data = np.zeros((200, 200, 4), dtype=np.int8)
+>>> data = np.zeros((200, 200, 4), dtype=np.uint8)
 >>> data[:, :] = [255, 0, 0, 255] # Red
 >>> # In PIL, RGBA images consist of 32-bit integers whose bytes are [RR,GG,BB,AA]
 >>> data = data.view(np.int32).squeeze()


### PR DESCRIPTION
Avoid
```
1259 - But it's integrated into Python  (e.g. strings support it)
1260
1261 Mini-exercise using `Pillow <https://python-pillow.org/>`_ (Python
1262 Imaging Library):
1263
1264 .. seealso:: pilbuffer.py
1265
1266 >>> from PIL import Image
1267 >>> data = np.zeros((200, 200, 4), dtype=np.int8)
1268 >>> data[:, :] = [255, 0, 0, 255] # Red
UNEXPECTED EXCEPTION: DeprecationWarning('NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 255 to int8 will fail in the future.\nFor the old behavior, usually:\n    np.array(value).astype(dtype)\nwill give the desired result (the cast overflows).')
Traceback (most recent call last):
  File "/usr/lib64/python3.11/doctest.py", line 1351, in __run
    exec(compile(example.source, filename, "single",
  File "<doctest index.rst[151]>", line 1, in <module>
DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 255 to int8 will fail in the future.
For the old behavior, usually:
    np.array(value).astype(dtype)
will give the desired result (the cast overflows).
/home/jarrod/src/scipy-lecture-notes/advanced/advanced_numpy/index.rst:1268: UnexpectedException
```