### PR TITLE
Avoid indexing with 'np.bool_' scalars

### DIFF
--- a/advanced/image_processing/index.rst
+++ b/advanced/image_processing/index.rst
@@ -780,7 +780,7 @@ Now reassign labels with ``np.searchsorted``::
 
 Find region of interest enclosing object::
 
-    >>> slice_x, slice_y = sp.ndimage.find_objects(label_im==4)[0]
+    >>> slice_x, slice_y = sp.ndimage.find_objects((label_im==4).astype(int))[0]
     >>> roi = im[slice_x, slice_y]
     >>> plt.imshow(roi)
     <matplotlib.image.AxesImage object at 0x...>

--- a/intro/scipy/image_processing/image_processing.rst
+++ b/intro/scipy/image_processing/image_processing.rst
@@ -287,9 +287,9 @@ Now compute measurements on each connected component::
 
 Extract the 4th connected component, and crop the array around it::
 
-    >>> sp.ndimage.find_objects(labels==4) # doctest: +SKIP
-    [(slice(30L, 48L, None), slice(30L, 48L, None))]
-    >>> sl = sp.ndimage.find_objects(labels==4)
+    >>> sp.ndimage.find_objects((labels==4).astype(int))
+    [(slice(30, 48, None), slice(30, 48, None))]
+    >>> sl = sp.ndimage.find_objects((labels==4).astype(int))
     >>> import matplotlib.pyplot as plt
     >>> plt.imshow(sig[sl[0]])
     <matplotlib.image.AxesImage object at ...>


### PR DESCRIPTION
Avoid
```
283     :target: auto_examples/plot_connect_measurements.html
284     :scale: 60
285     :align: right
286
287
288 Extract the 4th connected component, and crop the array around it::
289
290     >>> sp.ndimage.find_objects(labels==4) # doctest: +SKIP
291     [(slice(30L, 48L, None), slice(30L, 48L, None))]
292     >>> sl = sp.ndimage.find_objects(labels==4)
UNEXPECTED EXCEPTION: DeprecationWarning("In future, it will be an error for 'np.bool_' scalars to be interpreted as an index")
Traceback (most recent call last):
  File "/usr/lib64/python3.11/doctest.py", line 1351, in __run
    exec(compile(example.source, filename, "single",
  File "<doctest image_processing.rst[61]>", line 1, in <module>
  File "/home/jarrod/.venv/lectures/lib64/python3.11/site-packages/scipy/ndimage/_measurements.py", line 308, in find_objects
    return _nd_image.find_objects(input, max_label)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
DeprecationWarning: In future, it will be an error for 'np.bool_' scalars to be interpreted as an index
/home/jarrod/src/scipy-lecture-notes/intro/scipy/image_processing/image_processing.rst:292: UnexpectedException
```