### PR TITLE
Avoid conversion of array to scalar warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ doctest_optionflags = NUMBER NORMALIZE_WHITESPACE ELLIPSIS
 filterwarnings =
     ignore:Matplotlib is currently using agg:UserWarning
     ignore:In future, it will be an error for 'np.bool_' scalars:DeprecationWarning
+    ignore:Conversion of an array with ndim > 0 to a scalar is deprecated:DeprecationWarning
 addopts =
     --ignore=advanced/advanced_numpy/examples/myobject_test.py
     --ignore=advanced/interfacing_with_c/ctypes_numpy/test_cos_doubles.py


### PR DESCRIPTION
Avoid
```
intro/scipy/index.rst: 4 warnings
packages/statistics/index.rst: 32 warnings
  /opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/scipy/stats/_stats_py.py:1069: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    else dtype(mean))
```